### PR TITLE
Feat: 애플리케이션 전역 타임존을 Asia/Seoul로 설정 및 Docker Compose 파일에 타임존 추가

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -10,11 +10,17 @@ services:
       MYSQL_DATABASE: haruharu
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
+      TZ: Asia/Seoul  # 타임존 설정
     volumes:
       - mysql-data:/var/lib/mysql
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
+      - --character-set-client-handshake=FALSE
+      - --init-connect=SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci
+      - --init-connect=SET collation_connection = utf8mb4_unicode_ci
+      - --skip-character-set-client-handshake
+      - --default-time-zone=+09:00  # MySQL 타임존 설정
     healthcheck:
       test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
       interval: 10s

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -8,11 +8,17 @@ services:
       MYSQL_DATABASE: haruharu
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
+      TZ: Asia/Seoul  # 타임존 설정
     volumes:
       - mysql-data:/var/lib/mysql
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
+      - --character-set-client-handshake=FALSE
+      - --init-connect=SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci
+      - --init-connect=SET collation_connection = utf8mb4_unicode_ci
+      - --skip-character-set-client-handshake
+      - --default-time-zone=+09:00  # MySQL 타임존 설정
     healthcheck:
       test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
       interval: 10s
@@ -31,6 +37,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: staging
       JAVA_OPTS: -Xms256m -Xmx512m -XX:+UseG1GC -XX:MaxGCPauseMillis=100
+      TZ: Asia/Seoul  # 타임존 설정
     networks:
       - haruharu-network
     depends_on:

--- a/src/main/java/org/kwakmunsu/haruhana/global/config/TimeZoneConfig.java
+++ b/src/main/java/org/kwakmunsu/haruhana/global/config/TimeZoneConfig.java
@@ -1,0 +1,21 @@
+package org.kwakmunsu.haruhana.global.config;
+
+import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 타임존 설정
+ *
+ * <p>애플리케이션 전체의 타임존을 Asia/Seoul로 설정합니다.
+ * 이를 통해 로그, 데이터베이스 시간 등이 한국 시간(KST)으로 일관되게 처리됩니다.
+ */
+@Configuration
+public class TimeZoneConfig {
+
+    @PostConstruct
+    public void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,8 @@ spring:
   web:
     resources:
       add-mappings: false
+  jackson:
+    time-zone: Asia/Seoul  # JSON 직렬화/역직렬화 시 타임존
 
 server:
   tomcat:


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`:  #66 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **설정 변경**
  * 애플리케이션의 기본 타임존을 한국 시간(Asia/Seoul)으로 통일했습니다.
  * 데이터베이스, API 응답, 로그 기록 등 모든 시간 관련 처리에서 일관된 한국 시간대가 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->