### PR TITLE
Refactor: 엔드포인트 간에 일관된 'ApiResponse' 객체를 반환하도록 변경

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import org.kwakmunsu.haruhana.domain.auth.service.AuthService;
 import org.kwakmunsu.haruhana.global.annotation.LoginMember;
 import org.kwakmunsu.haruhana.global.security.jwt.dto.TokenResponse;
 import org.kwakmunsu.haruhana.global.support.response.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,10 +38,11 @@ public class AuthController extends AuthDocsController {
 
     @Override
     @PostMapping("/v1/auth/logout")
-    public ResponseEntity<Void> logout(@LoginMember Long memberId) {
+    public ResponseEntity<ApiResponse<?>> logout(@LoginMember Long memberId) {
         authService.logout(memberId);
 
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .body(ApiResponse.success());
     }
 
 }

--- a/src/main/java/org/kwakmunsu/haruhana/domain/auth/controller/AuthDocsController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/auth/controller/AuthDocsController.java
@@ -62,6 +62,6 @@ public abstract class AuthDocsController {
             ErrorType.NOT_FOUND_MEMBER,
             ErrorType.DEFAULT_ERROR
     })
-    public abstract ResponseEntity<Void> logout(@LoginMember Long memberId);
+    public abstract ResponseEntity<ApiResponse<?>> logout(@LoginMember Long memberId);
 
 }

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberController.java
@@ -34,8 +34,7 @@ public class MemberController extends MemberDocsController {
     public ResponseEntity<ApiResponse<Long>> create(@RequestBody @Valid MemberCreateRequest request) {
         Long memberId = memberService.createMember(request.toNewProfile(), request.toNewPreference());
 
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
+        return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(memberId));
     }
 
@@ -66,15 +65,16 @@ public class MemberController extends MemberDocsController {
     ) {
         memberService.updateProfile(request.toUpdateProfile(), memberId);
 
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.success());
     }
 
     @Override
     @DeleteMapping("/v1/members")
-    public ResponseEntity<Void> withdraw(@LoginMember Long memberId) {
+    public ResponseEntity<ApiResponse<?>> withdraw(@LoginMember Long memberId) {
         memberService.withdraw(memberId);
 
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .body(ApiResponse.success());
     }
 
     @Override
@@ -90,13 +90,14 @@ public class MemberController extends MemberDocsController {
 
     @Override
     @DeleteMapping("/v1/members/devices")
-    public ResponseEntity<Void> deleteDevices(
+    public ResponseEntity<ApiResponse<?>> deleteDevices(
             @RequestParam String deviceToken,
             @LoginMember Long memberId
     ) {
         memberService.deleteDeviceTokens(deviceToken, memberId);
 
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .body(ApiResponse.success());
     }
 
     @Override

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberDocsController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberDocsController.java
@@ -138,7 +138,7 @@ public abstract class MemberDocsController {
             NOT_FOUND_MEMBER,
             DEFAULT_ERROR
     })
-    public abstract ResponseEntity<Void> withdraw(Long memberId);
+    public abstract ResponseEntity<ApiResponse<?>> withdraw(Long memberId);
 
     @Operation(
             summary = "닉네임 사용 가능 여부 확인 - JWT [X]",
@@ -182,7 +182,7 @@ public abstract class MemberDocsController {
             NOT_FOUND_FCM_TOKEN,
             DEFAULT_ERROR
     })
-    public abstract ResponseEntity<Void> deleteDevices(
+    public abstract ResponseEntity<ApiResponse<?>> deleteDevices(
             String deviceToken,
             Long memberId
     );


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`:  #109 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 여러 API 엔드포인트의 응답 형식을 표준화했습니다.
  * 로그아웃, 회원탈퇴, 기기 삭제 등 주요 기능의 응답 구조를 일관되게 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->