### PR TITLE
Feat: 관리자용 회원 선호도 조회 API 구현 (#116)

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberController.java
@@ -3,12 +3,14 @@ package org.kwakmunsu.haruhana.admin.member.controller;
 import lombok.RequiredArgsConstructor;
 import org.kwakmunsu.haruhana.admin.member.enums.SortBy;
 import org.kwakmunsu.haruhana.admin.member.service.AdminMemberService;
+import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreferenceResponse;
 import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreviewResponse;
 import org.kwakmunsu.haruhana.global.support.OffsetLimit;
 import org.kwakmunsu.haruhana.global.support.response.ApiResponse;
 import org.kwakmunsu.haruhana.global.support.response.PageResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,6 +33,14 @@ public class AdminMemberController extends AdminMemberDocsController {
                 sortBy,
                 new OffsetLimit(page, size)
         );
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Override
+    @GetMapping("/v1/admin/members/{memberId}/preferences")
+    public ResponseEntity<ApiResponse<AdminMemberPreferenceResponse>> findMemberPreference(@PathVariable Long memberId) {
+        AdminMemberPreferenceResponse response = adminMemberService.findMemberPreference(memberId);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberDocsController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberDocsController.java
@@ -5,10 +5,15 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.kwakmunsu.haruhana.admin.member.enums.SortBy;
+import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreferenceResponse;
 import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreviewResponse;
+import org.kwakmunsu.haruhana.global.support.error.ErrorType;
 import org.kwakmunsu.haruhana.global.support.response.ApiResponse;
 import org.kwakmunsu.haruhana.global.support.response.PageResponse;
+import org.kwakmunsu.haruhana.global.swagger.ApiExceptions;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "Admin - Member", description = "관리자용 Member 관련 API 문서")
 public abstract class AdminMemberDocsController {
@@ -47,6 +52,28 @@ public abstract class AdminMemberDocsController {
                     in = ParameterIn.QUERY
             )
             int size
+    );
+
+    @Operation(
+            summary = "회원 선호도 조회 - 관리자",
+            description = """
+                    #### 특정 회원의 선호도를 조회하는 API입니다.
+                    - 관리자는 회원의 ID를 통해 해당 회원이 설정한 선호도를 조회할 수 있습니다.
+                    - 선호도에는 카테고리 주제, 난이도, 효과 발생 날짜 등의 정보가 포함됩니다.
+                    """
+    )
+    @ApiExceptions(values = {
+            ErrorType.DEFAULT_ERROR,
+            ErrorType.NOT_FOUND_MEMBER_PREFERENCE,
+            ErrorType.UNAUTHORIZED_ERROR
+    })
+    public abstract ResponseEntity<ApiResponse<AdminMemberPreferenceResponse>> findMemberPreference(
+            @Parameter(
+                    example = "1",
+                    description = "회원 ID",
+                    in = ParameterIn.PATH
+            )
+            Long memberId
     );
 
 }

--- a/src/main/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberReader.java
+++ b/src/main/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberReader.java
@@ -3,10 +3,17 @@ package org.kwakmunsu.haruhana.admin.member.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.kwakmunsu.haruhana.admin.member.enums.SortBy;
+import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreferenceResponse;
 import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreviewResponse;
 import org.kwakmunsu.haruhana.domain.member.entity.Member;
+import org.kwakmunsu.haruhana.domain.member.entity.MemberPreference;
+import org.kwakmunsu.haruhana.domain.member.repository.MemberJpaRepository;
+import org.kwakmunsu.haruhana.domain.member.repository.MemberPreferenceJpaRepository;
 import org.kwakmunsu.haruhana.domain.member.repository.MemberQueryDslRepository;
+import org.kwakmunsu.haruhana.global.entity.EntityStatus;
 import org.kwakmunsu.haruhana.global.support.OffsetLimit;
+import org.kwakmunsu.haruhana.global.support.error.ErrorType;
+import org.kwakmunsu.haruhana.global.support.error.HaruHanaException;
 import org.kwakmunsu.haruhana.global.support.response.PageResponse;
 import org.springframework.stereotype.Component;
 
@@ -15,6 +22,7 @@ import org.springframework.stereotype.Component;
 public class AdminMemberReader {
 
     private final MemberQueryDslRepository memberQueryDslRepository;
+    private final MemberPreferenceJpaRepository memberPreferenceJpaRepository;
 
     public PageResponse<AdminMemberPreviewResponse> findMembers(String search, SortBy sortBy, OffsetLimit offsetLimit) {
         List<Member> members = memberQueryDslRepository.findMembers(search, sortBy, offsetLimit);
@@ -31,6 +39,13 @@ public class AdminMemberReader {
                 .contents(memberResponses)
                 .hasNext(hasNext)
                 .build();
+    }
+
+    public AdminMemberPreferenceResponse findMemberPreference(Long memberId) {
+        MemberPreference memberPreference = memberPreferenceJpaRepository.findByMemberIdAndStatus(memberId, EntityStatus.ACTIVE)
+                .orElseThrow(() -> new HaruHanaException(ErrorType.NOT_FOUND_MEMBER_PREFERENCE));
+
+        return AdminMemberPreferenceResponse.from(memberPreference);
     }
 
 }

--- a/src/main/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberService.java
+++ b/src/main/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberService.java
@@ -2,6 +2,7 @@ package org.kwakmunsu.haruhana.admin.member.service;
 
 import lombok.RequiredArgsConstructor;
 import org.kwakmunsu.haruhana.admin.member.enums.SortBy;
+import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreferenceResponse;
 import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreviewResponse;
 import org.kwakmunsu.haruhana.global.support.OffsetLimit;
 import org.kwakmunsu.haruhana.global.support.response.PageResponse;
@@ -13,8 +14,12 @@ public class AdminMemberService {
 
     private final AdminMemberReader memberReader;
 
-    public  PageResponse<AdminMemberPreviewResponse> findMembers(String search, SortBy sortBy, OffsetLimit offsetLimit) {
-       return memberReader.findMembers(search, sortBy, offsetLimit);
+    public PageResponse<AdminMemberPreviewResponse> findMembers(String search, SortBy sortBy, OffsetLimit offsetLimit) {
+        return memberReader.findMembers(search, sortBy, offsetLimit);
+    }
+
+    public AdminMemberPreferenceResponse findMemberPreference(Long memberId) {
+        return memberReader.findMemberPreference(memberId);
     }
 
 }

--- a/src/main/java/org/kwakmunsu/haruhana/admin/member/service/dto/AdminMemberPreferenceResponse.java
+++ b/src/main/java/org/kwakmunsu/haruhana/admin/member/service/dto/AdminMemberPreferenceResponse.java
@@ -1,0 +1,37 @@
+package org.kwakmunsu.haruhana.admin.member.service.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import lombok.Builder;
+import org.kwakmunsu.haruhana.domain.member.entity.MemberPreference;
+
+@Schema(description = "관리자 회원 선호도 응답 DTO")
+@Builder
+public record AdminMemberPreferenceResponse(
+        @Schema(description = "선호도 ID", example = "1")
+        Long id,
+
+        @Schema(description = "회원 ID", example = "1")
+        Long memberId,
+
+        @Schema(description = "카테고리 주제 이름", example = "개발")
+        String categoryTopic,
+
+        @Schema(description = "선호도 난이도", example = "상")
+        String difficulty,
+
+        @Schema(description = "선호도 효과 발생 날짜", example = "2024-01-01")
+        LocalDate effectiveAt
+) {
+
+    public static AdminMemberPreferenceResponse from(MemberPreference memberPreference) {
+        return AdminMemberPreferenceResponse.builder()
+                .id(memberPreference.getId())
+                .memberId(memberPreference.getMember().getId())
+                .categoryTopic(memberPreference.getCategoryTopic().getName())
+                .difficulty(memberPreference.getDifficulty().name())
+                .effectiveAt(memberPreference.getEffectiveAt())
+                .build();
+    }
+
+}

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/repository/MemberPreferenceJpaRepository.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/repository/MemberPreferenceJpaRepository.java
@@ -14,6 +14,8 @@ import org.springframework.data.repository.query.Param;
 public interface MemberPreferenceJpaRepository extends JpaRepository<MemberPreference, Long> {
 
     List<MemberPreference> findAllByEffectiveAtLessThanEqualAndStatus(LocalDate effectiveAt, EntityStatus status);
+
+    @Query("SELECT mp FROM MemberPreference mp JOIN FETCH mp.categoryTopic WHERE mp.member.id = :memberId AND mp.status = :status")
     Optional<MemberPreference> findByMemberIdAndStatus(Long memberId, EntityStatus status);
 
     @Query("SELECT mp FROM MemberPreference mp JOIN FETCH mp.member m JOIN FETCH mp.categoryTopic WHERE m.id = :memberId AND mp.status = :status")
@@ -22,4 +24,5 @@ public interface MemberPreferenceJpaRepository extends JpaRepository<MemberPrefe
     @Modifying
     @Query("UPDATE MemberPreference mp SET mp.status = :status, mp.updatedAt = :now WHERE mp.member.id = :memberId AND mp.status = 'ACTIVE'")
     void softDeleteByMemberId(@Param("memberId") Long memberId, @Param("status") EntityStatus status, @Param("now") LocalDateTime now);
+
 }

--- a/src/main/java/org/kwakmunsu/haruhana/global/support/error/ErrorType.java
+++ b/src/main/java/org/kwakmunsu/haruhana/global/support/error/ErrorType.java
@@ -27,6 +27,7 @@ public enum ErrorType {
     NOT_FOUND_ACTIVE_MEMBER_BY_REFRESH_TOKEN (HttpStatus.NOT_FOUND, "요청하신 Refresh Token 으로 활성화 된 회원을 찾을 수 없습니다.", LogLevel.INFO),
     DUPLICATE_LOGIN_ID                       (HttpStatus.CONFLICT, "이미 사용 중인 로그인 아이디입니다.", LogLevel.INFO),
     DUPLICATE_NICKNAME                       (HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.", LogLevel.INFO),
+    NOT_FOUND_MEMBER_PREFERENCE(HttpStatus.NOT_FOUND, "회원 선호 정보를 찾을 수 없습니다.", LogLevel.ERROR), // 회원 정보는 없으면 안되기에 Error
 
     // MEMBER DEVICE
     NOT_FOUND_MEMBER_DEVICE (HttpStatus.NOT_FOUND, "회원 디바이스 정보를 찾을 수 없습니다.", LogLevel.INFO),
@@ -76,8 +77,8 @@ public enum ErrorType {
     FAILED_TO_UPLOAD_FILE  (HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패하였습니다.", LogLevel.ERROR),
     FILE_SIZE_EXCEEDED     (HttpStatus.INTERNAL_SERVER_ERROR, "파일 크기가 허용된 최대 크기를 초과하였습니다.", LogLevel.ERROR),
     S3_PRESIGNED_URL_ERROR (HttpStatus.INTERNAL_SERVER_ERROR,"presigned-url 생성에 실패하였습니다." , LogLevel.ERROR),
-    ;
 
+    ;
     private final HttpStatus status;
     private final String message;
     private final LogLevel logLevel;

--- a/src/test/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberControllerTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberControllerTest.java
@@ -5,13 +5,16 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.kwakmunsu.haruhana.ControllerTestSupport;
 import org.kwakmunsu.haruhana.admin.member.enums.SortBy;
+import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreferenceResponse;
 import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreviewResponse;
 import org.kwakmunsu.haruhana.domain.member.enums.Role;
+import org.kwakmunsu.haruhana.domain.problem.enums.ProblemDifficulty;
 import org.kwakmunsu.haruhana.global.entity.EntityStatus;
 import org.kwakmunsu.haruhana.global.support.response.PageResponse;
 import org.kwakmunsu.haruhana.security.annotation.TestAdmin;
@@ -59,6 +62,33 @@ class AdminMemberControllerTest extends ControllerTestSupport {
                 .hasPathSatisfying("$.data.contents[0].role", v -> v.assertThat().isEqualTo("ROLE_MEMBER"))
                 .hasPathSatisfying("$.data.contents[0].lastLoginAt", v -> v.assertThat().isNotNull())
                 .hasPathSatisfying("$.data.contents[0].createdAt", v -> v.assertThat().isNotNull());
+    }
+
+    @TestAdmin
+    @Test
+    void 관리자용_회원_학습_정보_조회_Api를_요청한다() {
+        // given
+        LocalDate effectiveAt = TestDateTimeUtils.now().toLocalDate();
+
+        var response = AdminMemberPreferenceResponse.builder()
+                .id(1L)
+                .memberId(1L)
+                .categoryTopic("JAVA")
+                .difficulty(ProblemDifficulty.EASY.name())
+                .effectiveAt(effectiveAt)
+                .build();
+
+        given(adminMemberService.findMemberPreference(any())).willReturn(response);
+
+        // when & then
+        assertThat(mvcTester.get().uri("/v1/admin/members/{memberId}/preferences", 1L))
+                .apply(print())
+                .hasStatusOk()
+                .bodyJson()
+                .hasPathSatisfying("$.data.memberId", v -> v.assertThat().isEqualTo(response.memberId().intValue()))
+                .hasPathSatisfying("$.data.categoryTopic", v -> v.assertThat().isEqualTo(response.categoryTopic()))
+                .hasPathSatisfying("$.data.difficulty", v -> v.assertThat().isEqualTo(response.difficulty()))
+                .hasPathSatisfying("$.data.effectiveAt", v -> v.assertThat().isNotNull());
     }
 
 }

--- a/src/test/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberReaderUnitTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberReaderUnitTest.java
@@ -1,23 +1,35 @@
 package org.kwakmunsu.haruhana.admin.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.kwakmunsu.haruhana.UnitTestSupport;
 import org.kwakmunsu.haruhana.admin.member.enums.SortBy;
+import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreferenceResponse;
 import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreviewResponse;
+import org.kwakmunsu.haruhana.domain.category.entity.CategoryTopic;
 import org.kwakmunsu.haruhana.domain.member.MemberFixture;
 import org.kwakmunsu.haruhana.domain.member.entity.Member;
+import org.kwakmunsu.haruhana.domain.member.entity.MemberPreference;
 import org.kwakmunsu.haruhana.domain.member.enums.Role;
+import org.kwakmunsu.haruhana.domain.member.repository.MemberPreferenceJpaRepository;
 import org.kwakmunsu.haruhana.domain.member.repository.MemberQueryDslRepository;
+import org.kwakmunsu.haruhana.domain.problem.enums.ProblemDifficulty;
 import org.kwakmunsu.haruhana.global.entity.EntityStatus;
 import org.kwakmunsu.haruhana.global.support.OffsetLimit;
+import org.kwakmunsu.haruhana.global.support.error.ErrorType;
+import org.kwakmunsu.haruhana.global.support.error.HaruHanaException;
 import org.kwakmunsu.haruhana.global.support.response.PageResponse;
+import org.kwakmunsu.haruhana.util.TestDateTimeUtils;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
@@ -25,6 +37,9 @@ class AdminMemberReaderUnitTest extends UnitTestSupport {
 
     @Mock
     MemberQueryDslRepository memberQueryDslRepository;
+
+    @Mock
+    MemberPreferenceJpaRepository memberPreferenceJpaRepository;
 
     @InjectMocks
     AdminMemberReader adminMemberReader;
@@ -106,6 +121,52 @@ class AdminMemberReaderUnitTest extends UnitTestSupport {
         ).containsExactly(
                 tuple("user2", "유저2", Role.ROLE_MEMBER, EntityStatus.ACTIVE)
         );
+    }
+
+    @Test
+    void 회원_학습_정보를_조회한다() {
+        // given
+        LocalDate effectiveAt = TestDateTimeUtils.now().toLocalDate();
+        var member = mock(Member.class);
+        given(member.getId()).willReturn(1L);
+
+        var spring = CategoryTopic.create(1L, "Spring");
+        var mockedPreference = mock(MemberPreference.class);
+
+        given(mockedPreference.getId()).willReturn(1L);
+        given(mockedPreference.getMember()).willReturn(member);
+        given(mockedPreference.getCategoryTopic()).willReturn(spring);
+        given(mockedPreference.getDifficulty()).willReturn(ProblemDifficulty.EASY);
+        given(mockedPreference.getEffectiveAt()).willReturn(effectiveAt);
+
+        given(memberPreferenceJpaRepository.findByMemberIdAndStatus(any(), any())).willReturn(Optional.of(mockedPreference));
+
+        // when
+        var adminMemberReaderMemberPreference = adminMemberReader.findMemberPreference(1L);
+
+        // then
+        assertThat(adminMemberReaderMemberPreference).isNotNull()
+                .extracting(
+                        AdminMemberPreferenceResponse::memberId,
+                        AdminMemberPreferenceResponse::categoryTopic,
+                        AdminMemberPreferenceResponse::difficulty,
+                        AdminMemberPreferenceResponse::effectiveAt
+                ).containsExactly(
+                        1L,
+                        spring.getName(),
+                        ProblemDifficulty.EASY.name(),
+                        effectiveAt
+                );
+    }
+
+    @Test
+    void 회원_학습_정보가_없을_시_예외를_반환한다() {
+        given(memberPreferenceJpaRepository.findByMemberIdAndStatus(any(), any())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminMemberReader.findMemberPreference(1L))
+                .isInstanceOf(HaruHanaException.class)
+                .hasMessage(ErrorType.NOT_FOUND_MEMBER_PREFERENCE.getMessage());
     }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`:  #116 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자가 회원의 학습 선호 정보를 조회할 수 있는 새로운 API 엔드포인트 추가. 회원별 카테고리 주제, 난이도, 유효 일자 정보를 조회할 수 있습니다.
  * 선호 정보 미존재 시 명확한 오류 응답 처리 추가.

* **테스트**
  * 새로운 API 엔드포인트 및 서비스 기능에 대한 단위 테스트 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->