### PR TITLE
Feat: 관리자용 회원 비활성화 기능 구현 (#125)

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberController.java
@@ -12,6 +12,7 @@ import org.kwakmunsu.haruhana.global.support.response.ApiResponse;
 import org.kwakmunsu.haruhana.global.support.response.PageResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -57,6 +58,16 @@ public class AdminMemberController extends AdminMemberDocsController {
             @Valid @RequestBody MemberUpdateRoleRequest request
     ) {
         adminMemberService.updateRole(memberId,request.role());
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.success());
+    }
+
+    @Override
+    @DeleteMapping("/v1/admin/members/{memberId}")
+    public ResponseEntity<ApiResponse<?>> deleteMember(
+            @PathVariable Long memberId
+    ) {
+        adminMemberService.deleteMember(memberId);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.success());
     }

--- a/src/main/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberDocsController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberDocsController.java
@@ -13,7 +13,6 @@ import org.kwakmunsu.haruhana.global.support.response.ApiResponse;
 import org.kwakmunsu.haruhana.global.support.response.PageResponse;
 import org.kwakmunsu.haruhana.global.swagger.ApiExceptions;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
 
 @Tag(name = "Admin - Member", description = "관리자용 Member 관련 API 문서")
 public abstract class AdminMemberDocsController {
@@ -102,6 +101,32 @@ public abstract class AdminMemberDocsController {
             )
             Long memberId,
             MemberUpdateRoleRequest request
+    );
+
+    @Operation(
+            summary = "회원 삭제 - 관리자",
+            description = """
+                    #### 특정 회원을 삭제하는 API입니다.
+                    - 관리자는 회원의 ID를 제공하여 해당 회원을 삭제할 수 있습니다.
+                    - 이 API는 성공적으로 회원이 삭제되면 204 No Content 상태 코드를 반환합니다.
+                    """
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "204",
+            description = "회원이 성공적으로 삭제되었습니다."
+    )
+    @ApiExceptions(values = {
+            ErrorType.DEFAULT_ERROR,
+            ErrorType.NOT_FOUND_MEMBER,
+            ErrorType.UNAUTHORIZED_ERROR
+    })
+    public abstract ResponseEntity<ApiResponse<?>> deleteMember(
+            @Parameter(
+                    example = "1",
+                    description = "회원 ID",
+                    in = ParameterIn.PATH
+            )
+            Long memberId
     );
 
 }

--- a/src/main/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberManager.java
+++ b/src/main/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberManager.java
@@ -24,4 +24,14 @@ public class AdminMemberManager {
         member.updateRole(role);
     }
 
+    @Transactional
+    public void deleteMember(Long memberId) {
+        Member member = memberJpaRepository.findById(memberId)
+                .orElseThrow(() -> new HaruHanaException(ErrorType.NOT_FOUND_MEMBER));
+
+        if (member.isDeleted()) return;
+
+        member.delete();
+    }
+
 }

--- a/src/main/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberReader.java
+++ b/src/main/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberReader.java
@@ -7,7 +7,6 @@ import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreferenceResp
 import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreviewResponse;
 import org.kwakmunsu.haruhana.domain.member.entity.Member;
 import org.kwakmunsu.haruhana.domain.member.entity.MemberPreference;
-import org.kwakmunsu.haruhana.domain.member.repository.MemberJpaRepository;
 import org.kwakmunsu.haruhana.domain.member.repository.MemberPreferenceJpaRepository;
 import org.kwakmunsu.haruhana.domain.member.repository.MemberQueryDslRepository;
 import org.kwakmunsu.haruhana.global.entity.EntityStatus;

--- a/src/main/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberService.java
+++ b/src/main/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberService.java
@@ -28,4 +28,8 @@ public class AdminMemberService {
         memberManager.updateMemberRole(memberId, role);
     }
 
+    public void deleteMember(Long memberId) {
+        memberManager.deleteMember(memberId);
+    }
+
 }

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberController.java
@@ -13,13 +13,13 @@ import org.kwakmunsu.haruhana.global.annotation.LoginMember;
 import org.kwakmunsu.haruhana.global.support.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RestController;
 
 @Validated

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberDocsController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberDocsController.java
@@ -4,7 +4,6 @@ import static org.kwakmunsu.haruhana.global.support.error.ErrorType.BAD_REQUEST;
 import static org.kwakmunsu.haruhana.global.support.error.ErrorType.DEFAULT_ERROR;
 import static org.kwakmunsu.haruhana.global.support.error.ErrorType.DUPLICATE_LOGIN_ID;
 import static org.kwakmunsu.haruhana.global.support.error.ErrorType.DUPLICATE_NICKNAME;
-import static org.kwakmunsu.haruhana.global.support.error.ErrorType.INVALID_NICKNAME;
 import static org.kwakmunsu.haruhana.global.support.error.ErrorType.NOT_FOUND_CATEGORY;
 import static org.kwakmunsu.haruhana.global.support.error.ErrorType.NOT_FOUND_FCM_TOKEN;
 import static org.kwakmunsu.haruhana.global.support.error.ErrorType.NOT_FOUND_MEMBER;
@@ -22,8 +21,6 @@ import org.kwakmunsu.haruhana.domain.member.service.MemberProfileResponse;
 import org.kwakmunsu.haruhana.global.support.response.ApiResponse;
 import org.kwakmunsu.haruhana.global.swagger.ApiExceptions;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Member Docs", description = "Member 관련 API 문서")
 public abstract class MemberDocsController {

--- a/src/main/java/org/kwakmunsu/haruhana/global/config/CacheConfig.java
+++ b/src/main/java/org/kwakmunsu/haruhana/global/config/CacheConfig.java
@@ -6,7 +6,6 @@ import com.github.benmanes.caffeine.cache.Expiry;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
 import java.time.Duration;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/org/kwakmunsu/haruhana/ControllerTestSupport.java
+++ b/src/test/java/org/kwakmunsu/haruhana/ControllerTestSupport.java
@@ -1,13 +1,13 @@
 package org.kwakmunsu.haruhana;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.kwakmunsu.haruhana.admin.category.controller.AdminCategoryController;
+import org.kwakmunsu.haruhana.admin.category.service.AdminCategoryService;
 import org.kwakmunsu.haruhana.admin.member.controller.AdminMemberController;
 import org.kwakmunsu.haruhana.admin.member.service.AdminMemberService;
 import org.kwakmunsu.haruhana.domain.auth.controller.AuthController;
 import org.kwakmunsu.haruhana.domain.auth.service.AuthService;
-import org.kwakmunsu.haruhana.admin.category.controller.AdminCategoryController;
 import org.kwakmunsu.haruhana.domain.category.controller.CategoryController;
-import org.kwakmunsu.haruhana.admin.category.service.AdminCategoryService;
 import org.kwakmunsu.haruhana.domain.category.service.CategoryService;
 import org.kwakmunsu.haruhana.domain.dailyproblem.controller.DailyProblemController;
 import org.kwakmunsu.haruhana.domain.dailyproblem.service.DailyProblemService;

--- a/src/test/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberControllerTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberControllerTest.java
@@ -3,13 +3,17 @@ package org.kwakmunsu.haruhana.admin.member.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.kwakmunsu.haruhana.ControllerTestSupport;
+import org.kwakmunsu.haruhana.admin.member.controller.dto.MemberUpdateRoleRequest;
 import org.kwakmunsu.haruhana.admin.member.enums.SortBy;
 import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreferenceResponse;
 import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreviewResponse;
@@ -19,6 +23,8 @@ import org.kwakmunsu.haruhana.global.entity.EntityStatus;
 import org.kwakmunsu.haruhana.global.support.response.PageResponse;
 import org.kwakmunsu.haruhana.security.annotation.TestAdmin;
 import org.kwakmunsu.haruhana.util.TestDateTimeUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
 class AdminMemberControllerTest extends ControllerTestSupport {
 
@@ -89,6 +95,35 @@ class AdminMemberControllerTest extends ControllerTestSupport {
                 .hasPathSatisfying("$.data.categoryTopic", v -> v.assertThat().isEqualTo(response.categoryTopic()))
                 .hasPathSatisfying("$.data.difficulty", v -> v.assertThat().isEqualTo(response.difficulty()))
                 .hasPathSatisfying("$.data.effectiveAt", v -> v.assertThat().isNotNull());
+    }
+
+    @TestAdmin
+    @Test
+    void 관리자용_회원_역할_변경_APi를_요청한다() throws JsonProcessingException {
+        // given
+        var request = new MemberUpdateRoleRequest(Role.ROLE_ADMIN);
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        // when & then
+        assertThat(mvcTester.patch().uri("/v1/admin/members/{memberId}/roles", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson))
+                .apply(print())
+                .hasStatus(HttpStatus.NO_CONTENT);
+
+        verify(adminMemberService, times(1)).updateRole(any(), any());
+    }
+
+    @TestAdmin
+    @Test
+    void 관리자용_회원_비활성화_APi를_요청한다() {
+
+        // when & then
+        assertThat(mvcTester.delete().uri("/v1/admin/members/{memberId}", 1L))
+                .apply(print())
+                .hasStatus(HttpStatus.NO_CONTENT);
+
+        verify(adminMemberService, times(1)).deleteMember(any());
     }
 
 }

--- a/src/test/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberManagerIntegrationTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberManagerIntegrationTest.java
@@ -65,4 +65,33 @@ class AdminMemberManagerIntegrationTest extends IntegrationTestSupport {
                 .hasMessage(ErrorType.NOT_FOUND_MEMBER.getMessage());
     }
 
+    @Test
+    void 관리자가_회원을_비활성화한다() {
+        // given
+        var member = MemberFixture.createMemberWithOutId(Role.ROLE_ADMIN);
+        memberJpaRepository.save(member);
+
+        // when
+        adminMemberManager.deleteMember(member.getId());
+        entityManager.flush();
+
+        // then
+        var deletedMember = memberJpaRepository.findById(member.getId()).orElseThrow();
+
+        assertThat(deletedMember.isDeleted()).isTrue();
+    }
+
+    @Test
+    void 이미_비활성화된_회원이라면_아무_일도_일어나지_않는다() {
+        // given
+        var member = MemberFixture.createMemberWithOutId(Role.ROLE_ADMIN);
+        memberJpaRepository.save(member);
+        adminMemberManager.deleteMember(member.getId());
+        entityManager.flush();
+
+        // when -  update 쿼리가 안나간다면 아무 일도 일어나지 않음.
+        adminMemberManager.deleteMember(member.getId());
+        entityManager.flush();
+    }
+
 }

--- a/src/test/java/org/kwakmunsu/haruhana/security/TestSecurityConfig.java
+++ b/src/test/java/org/kwakmunsu/haruhana/security/TestSecurityConfig.java
@@ -1,10 +1,8 @@
 package org.kwakmunsu.haruhana.security;
 
 import lombok.RequiredArgsConstructor;
-import org.kwakmunsu.haruhana.domain.member.enums.Role;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`: #125 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 API에 회원 비활성화 엔드포인트 추가 (DELETE /v1/admin/members/{memberId})
  * API 문서에 회원 비활성화 작업 관련 명세 추가

* **테스트**
  * 회원 비활성화 기능에 대한 단위 테스트 및 통합 테스트 추가

* **기타**
  * 코드 정리 및 미사용 임포트 제거
<!-- end of auto-generated comment: release notes by coderabbit.ai -->