### PR TITLE
Feat: 회원 프로필 응답에 역할 정보 추가

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberProfileResponse.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberProfileResponse.java
@@ -3,6 +3,7 @@ package org.kwakmunsu.haruhana.domain.member.service;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
+import org.kwakmunsu.haruhana.domain.member.entity.Member;
 import org.kwakmunsu.haruhana.domain.member.entity.MemberPreference;
 
 @Schema(description = "Member 프로필 응답 DTO")
@@ -23,18 +24,24 @@ public record MemberProfileResponse(
         @Schema(description = "학습 문제 난이도", example = "EASY")
         String difficulty,
 
+        @Schema(description = "회원 역할", example = "ROLE_MEMBER")
+        String role,
+
         @Schema(description = "조회용 presignedUrl", example = "https://example.com/profile-image.jpg")
         String profileImageUrl
 ) {
 
     public static MemberProfileResponse from(MemberPreference memberPreference, String profileImageUrl) {
         // NOTE: fetch join 사용으로 N + 1 문제 안터져요!
+        Member member = memberPreference.getMember();
+
         return MemberProfileResponse.builder()
-                .loginId(memberPreference.getMember().getLoginId())
-                .nickname(memberPreference.getMember().getNickname())
-                .createdAt(memberPreference.getMember().getCreatedAt())
+                .loginId(member.getLoginId())
+                .nickname(member.getNickname())
+                .createdAt(member.getCreatedAt())
                 .categoryTopicName(memberPreference.getCategoryTopic().getName())
                 .difficulty(memberPreference.getDifficulty().name())
+                .role(member.getRole().name())
                 .profileImageUrl(profileImageUrl)
                 .build();
     }

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/controller/MemberControllerTest.java
@@ -15,6 +15,7 @@ import org.kwakmunsu.haruhana.domain.member.MemberFixture;
 import org.kwakmunsu.haruhana.domain.member.controller.dto.DeviceTokenSyncRequest;
 import org.kwakmunsu.haruhana.domain.member.controller.dto.PreferenceUpdateRequest;
 import org.kwakmunsu.haruhana.domain.member.controller.dto.ProfileUpdateRequest;
+import org.kwakmunsu.haruhana.domain.member.enums.Role;
 import org.kwakmunsu.haruhana.domain.member.service.MemberProfileResponse;
 import org.kwakmunsu.haruhana.domain.problem.enums.ProblemDifficulty;
 import org.kwakmunsu.haruhana.security.annotation.TestMember;
@@ -53,6 +54,7 @@ class MemberControllerTest extends ControllerTestSupport {
                 LocalDateTime.now(),
                 "알고리즘",
                 ProblemDifficulty.EASY.name(),
+                Role.ROLE_MEMBER.name(),
                 null
         );
         given(memberService.getProfile(any())).willReturn(memberProfileResponse);
@@ -65,7 +67,8 @@ class MemberControllerTest extends ControllerTestSupport {
                 .hasPathSatisfying("$.data.loginId", v -> v.assertThat().isEqualTo(memberProfileResponse.loginId()))
                 .hasPathSatisfying("$.data.nickname", v -> v.assertThat().isEqualTo(memberProfileResponse.nickname()))
                 .hasPathSatisfying("$.data.categoryTopicName", v -> v.assertThat().isEqualTo(memberProfileResponse.categoryTopicName()))
-                .hasPathSatisfying("$.data.difficulty", v -> v.assertThat().isEqualTo(memberProfileResponse.difficulty()));
+                .hasPathSatisfying("$.data.difficulty", v -> v.assertThat().isEqualTo(memberProfileResponse.difficulty()))
+                .hasPathSatisfying("$.data.role", v -> v.assertThat().isEqualTo(memberProfileResponse.role()));
     }
 
     @TestMember


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`: #129 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 회원 프로필 응답에 역할(role) 정보 필드가 추가되었습니다. 이제 회원 프로필 조회 시 사용자의 역할 정보를 확인할 수 있습니다.

* **Tests**
  * 새로운 역할 필드 포함에 따라 테스트가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->