### PR TITLE
Feat: 관리자용 회원 닉네임 변경 기능 구현

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberController.java
@@ -2,6 +2,7 @@ package org.kwakmunsu.haruhana.admin.member.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.kwakmunsu.haruhana.admin.member.controller.dto.MemberUpdateNicknameRequest;
 import org.kwakmunsu.haruhana.admin.member.controller.dto.MemberUpdateRoleRequest;
 import org.kwakmunsu.haruhana.admin.member.enums.SortBy;
 import org.kwakmunsu.haruhana.admin.member.service.AdminMemberService;
@@ -49,6 +50,17 @@ public class AdminMemberController extends AdminMemberDocsController {
         AdminMemberPreferenceResponse response = adminMemberService.findMemberPreference(memberId);
 
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Override
+    @PatchMapping("/v1/admin/members/{memberId}/nicknames")
+    public ResponseEntity<ApiResponse<?>> updateMemberNickname(
+            @PathVariable Long memberId,
+            @Valid @RequestBody MemberUpdateNicknameRequest request
+    ) {
+        adminMemberService.updateNickname(memberId, request.nickname());
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.success());
     }
 
     @Override

--- a/src/main/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberDocsController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberDocsController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.kwakmunsu.haruhana.admin.member.controller.dto.MemberUpdateNicknameRequest;
 import org.kwakmunsu.haruhana.admin.member.controller.dto.MemberUpdateRoleRequest;
 import org.kwakmunsu.haruhana.admin.member.enums.SortBy;
 import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreferenceResponse;
@@ -73,6 +74,36 @@ public abstract class AdminMemberDocsController {
                     in = ParameterIn.PATH
             )
             Long memberId
+    );
+
+    @Operation(
+            summary = "회원 닉네임 변경 - 관리자",
+            description = """
+                    #### 특정 회원의 닉네임을 변경하는 API입니다.
+                    - 관리자는 회원의 ID와 새로운 닉네임을 제공하여 해당 회원의 닉네임을 변경할 수 있습니다.
+                    - 현재 닉네임과 동일한 경우 변경 없이 성공으로 처리됩니다.
+                    - 이미 사용 중인 닉네임으로는 변경할 수 없습니다.
+                    - 이 API는 성공적으로 닉네임이 변경되면 204 No Content 상태 코드를 반환합니다.
+                    """
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "204",
+            description = "회원 닉네임이 성공적으로 변경되었습니다."
+    )
+    @ApiExceptions(values = {
+            ErrorType.DEFAULT_ERROR,
+            ErrorType.NOT_FOUND_MEMBER,
+            ErrorType.DUPLICATE_NICKNAME,
+            ErrorType.UNAUTHORIZED_ERROR
+    })
+    public abstract ResponseEntity<ApiResponse<?>> updateMemberNickname(
+            @Parameter(
+                    example = "1",
+                    description = "회원 ID",
+                    in = ParameterIn.PATH
+            )
+            Long memberId,
+            MemberUpdateNicknameRequest request
     );
 
     @Operation(

--- a/src/main/java/org/kwakmunsu/haruhana/admin/member/controller/dto/MemberUpdateNicknameRequest.java
+++ b/src/main/java/org/kwakmunsu/haruhana/admin/member/controller/dto/MemberUpdateNicknameRequest.java
@@ -1,0 +1,15 @@
+package org.kwakmunsu.haruhana.admin.member.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "회원 닉네임 변경 요청 DTO")
+public record MemberUpdateNicknameRequest(
+        @Schema(description = "변경할 닉네임", example = "새닉네임")
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = 50, message = "닉네임은 최대 50자까지 가능합니다.")
+        String nickname
+) {
+
+}

--- a/src/main/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberManager.java
+++ b/src/main/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberManager.java
@@ -25,6 +25,22 @@ public class AdminMemberManager {
     }
 
     @Transactional
+    public void updateMemberNickname(Long memberId, String nickname) {
+        Member member = memberJpaRepository.findByIdAndStatus(memberId, EntityStatus.ACTIVE)
+                .orElseThrow(() -> new HaruHanaException(ErrorType.NOT_FOUND_MEMBER));
+
+        if (member.hasMatchingNickname(nickname)) {
+            return;
+        }
+
+        if (memberJpaRepository.existsByNicknameAndStatus(nickname, EntityStatus.ACTIVE)) {
+            throw new HaruHanaException(ErrorType.DUPLICATE_NICKNAME);
+        }
+
+        member.updateProfile(nickname);
+    }
+
+    @Transactional
     public void deleteMember(Long memberId) {
         Member member = memberJpaRepository.findById(memberId)
                 .orElseThrow(() -> new HaruHanaException(ErrorType.NOT_FOUND_MEMBER));

--- a/src/main/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberService.java
+++ b/src/main/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberService.java
@@ -28,6 +28,10 @@ public class AdminMemberService {
         memberManager.updateMemberRole(memberId, role);
     }
 
+    public void updateNickname(Long memberId, String nickname) {
+        memberManager.updateMemberNickname(memberId, nickname);
+    }
+
     public void deleteMember(Long memberId) {
         memberManager.deleteMember(memberId);
     }

--- a/src/test/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberControllerTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/admin/member/controller/AdminMemberControllerTest.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.kwakmunsu.haruhana.ControllerTestSupport;
+import org.kwakmunsu.haruhana.admin.member.controller.dto.MemberUpdateNicknameRequest;
 import org.kwakmunsu.haruhana.admin.member.controller.dto.MemberUpdateRoleRequest;
 import org.kwakmunsu.haruhana.admin.member.enums.SortBy;
 import org.kwakmunsu.haruhana.admin.member.service.dto.AdminMemberPreferenceResponse;
@@ -95,6 +96,38 @@ class AdminMemberControllerTest extends ControllerTestSupport {
                 .hasPathSatisfying("$.data.categoryTopic", v -> v.assertThat().isEqualTo(response.categoryTopic()))
                 .hasPathSatisfying("$.data.difficulty", v -> v.assertThat().isEqualTo(response.difficulty()))
                 .hasPathSatisfying("$.data.effectiveAt", v -> v.assertThat().isNotNull());
+    }
+
+    @TestAdmin
+    @Test
+    void 관리자용_회원_닉네임_변경_API를_요청한다() throws JsonProcessingException {
+        // given
+        var request = new MemberUpdateNicknameRequest("변경닉네임");
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        // when & then
+        assertThat(mvcTester.patch().uri("/v1/admin/members/{memberId}/nicknames", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson))
+                .apply(print())
+                .hasStatus(HttpStatus.NO_CONTENT);
+
+        verify(adminMemberService, times(1)).updateNickname(any(), any());
+    }
+
+    @TestAdmin
+    @Test
+    void 관리자용_회원_닉네임_변경_시_닉네임이_빈값이면_400을_반환한다() throws JsonProcessingException {
+        // given
+        var request = new MemberUpdateNicknameRequest("");
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        // when & then
+        assertThat(mvcTester.patch().uri("/v1/admin/members/{memberId}/nicknames", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson))
+                .apply(print())
+                .hasStatus(HttpStatus.BAD_REQUEST);
     }
 
     @TestAdmin

--- a/src/test/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberManagerIntegrationTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/admin/member/service/AdminMemberManagerIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import jakarta.persistence.EntityManager;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.kwakmunsu.haruhana.IntegrationTestSupport;
@@ -92,6 +93,61 @@ class AdminMemberManagerIntegrationTest extends IntegrationTestSupport {
         // when -  update 쿼리가 안나간다면 아무 일도 일어나지 않음.
         adminMemberManager.deleteMember(member.getId());
         entityManager.flush();
+    }
+
+    @Test
+    void 관리자가_회원_닉네임을_변경한다() {
+        // given
+        var member = MemberFixture.createMember("loginId1", "기존닉네임");
+        memberJpaRepository.save(member);
+
+        // when
+        adminMemberManager.updateMemberNickname(member.getId(), "변경닉네임");
+        entityManager.flush();
+
+        // then
+        var updatedMember = memberJpaRepository.findById(member.getId()).orElseThrow();
+        assertThat(updatedMember.getNickname()).isEqualTo("변경닉네임");
+    }
+
+    @Test
+    void 현재_닉네임과_동일한_닉네임으로_변경하면_변경_없이_처리된다() {
+        // given
+        var member = MemberFixture.createMemberWithOutId(Role.ROLE_MEMBER);
+        memberJpaRepository.save(member);
+
+        // when
+        adminMemberManager.updateMemberNickname(member.getId(), MemberFixture.NICKNAME);
+        entityManager.flush();
+
+        // then
+        var updatedMember = memberJpaRepository.findById(member.getId()).orElseThrow();
+        assertThat(updatedMember.getNickname()).isEqualTo(MemberFixture.NICKNAME);
+    }
+
+    @Test
+    void 이미_사용_중인_닉네임으로_변경하면_예외를_반환한다() {
+        // given
+        var member1 = MemberFixture.createMember("loginId1", "닉네임1");
+        var member2 = MemberFixture.createMember("loginId2", "닉네임2");
+        memberJpaRepository.saveAll(List.of(member1, member2));
+        entityManager.flush();
+
+        // when & then
+        assertThatThrownBy(() -> adminMemberManager.updateMemberNickname(member2.getId(), "닉네임1"))
+                .isInstanceOf(HaruHanaException.class)
+                .hasMessage(ErrorType.DUPLICATE_NICKNAME.getMessage());
+    }
+
+    @Test
+    void 존재하지_않는_회원의_닉네임을_변경하면_예외를_반환한다() {
+        // given
+        var nonExistentMemberId = 999999L;
+
+        // when & then
+        assertThatThrownBy(() -> adminMemberManager.updateMemberNickname(nonExistentMemberId, "변경닉네임"))
+                .isInstanceOf(HaruHanaException.class)
+                .hasMessage(ErrorType.NOT_FOUND_MEMBER.getMessage());
     }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`: #139 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **관리자용 회원 닉네임 변경 기능 추가** - 관리자가 회원의 닉네임을 변경할 수 있는 새로운 API 엔드포인트가 추가되었습니다. 닉네임은 최대 50자까지 입력 가능하며, 중복된 닉네임은 사용할 수 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->