### PR TITLE
  Revert: main에 직접 머지된 #143 커밋 되돌리기

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -81,7 +81,7 @@ jobs:
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           port: 22
           script: |
-            mkdir -p ~/haruharu-prod/nginx/static
+            mkdir -p ~/haruharu-prod/nginx
             cd ~/haruharu-prod
 
             # 환경변수 파일 생성
@@ -99,11 +99,6 @@ jobs:
             # nginx 설정 파일 생성
             cat > ./nginx/prod.conf << 'EOF'
             ${{ secrets.NGINX_PROD_CONF }}
-            EOF
-
-            # nginx static 파일 생성
-            cat > ./nginx/static/quotes.json << 'EOF'
-            ${{ secrets.NGINX_STATIC_QUOTES_JSON }}
             EOF
 
             # 1. app 컨테이너만 중지 (인프라 컨테이너는 유지)

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -80,7 +80,7 @@ jobs:
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           port: 22
           script: |
-            mkdir -p ~/haruharu-staging/nginx/static
+            mkdir -p ~/haruharu-staging/nginx
             cd ~/haruharu-staging
 
             # 환경변수 파일 생성
@@ -101,11 +101,6 @@ jobs:
             # nginx 설정 파일 생성
             cat > ./nginx/staging.conf << 'EOF'
             ${{ secrets.NGINX_STAGING_CONF }}
-            EOF
-
-            # nginx static 파일 생성
-            cat > ./nginx/static/quotes.json << 'EOF'
-            ${{ secrets.NGINX_STATIC_QUOTES_JSON }}
             EOF
 
             # 1. app 컨테이너만 중지 (인프라 컨테이너는 유지)

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -21,7 +21,6 @@ services:
       - "443:443"
     volumes:
       - ./nginx/prod.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./nginx/static:/etc/nginx/static:ro
       - /etc/letsencrypt/live:/etc/letsencrypt/live:ro
       - /etc/letsencrypt/archive:/etc/letsencrypt/archive:ro
     depends_on:

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -49,7 +49,6 @@ services:
       - "443:443"
     volumes:
       - ./nginx/staging.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./nginx/static:/etc/nginx/static:ro
       - /etc/letsencrypt/live:/etc/letsencrypt/live:ro
       - /etc/letsencrypt/archive:/etc/letsencrypt/archive:ro
     depends_on:


### PR DESCRIPTION
  ## 제목
  Revert: main에 직접 머지된 #143 커밋 되돌리기

  ## 개요
  dev 브랜치를 거치지 않고 feature 브랜치에서 main으로 직접 머지된 커밋을 revert합니다.

  ## 원인
  - #143 커밋이 feature → main으로 실수로 직접 머지됨
  - 동일한 변경사항이 dev 브랜치 #144에 정상적으로 반영되어 있음

  ## 변경 파일
  - `.github/workflows/deploy-production.yml`
  - `.github/workflows/deploy-staging.yml`
  - `docker-compose-prod.yml`
  - `docker-compose-staging.yml`

  ## 이후 작업
  이 PR 머지 후 dev → main PR을 통해 정상 반영 예정