### PR TITLE
Feat: Error 레벨 예외 발생 시 슬랙 알림 전송 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 
     // Jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/main/java/org/kwakmunsu/haruhana/admin/problem/controller/AdminProblemController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/admin/problem/controller/AdminProblemController.java
@@ -2,8 +2,8 @@ package org.kwakmunsu.haruhana.admin.problem.controller;
 
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
-import org.kwakmunsu.haruhana.admin.problem.service.dto.AdminProblemPreviewResponse;
 import org.kwakmunsu.haruhana.admin.problem.service.AdminProblemService;
+import org.kwakmunsu.haruhana.admin.problem.service.dto.AdminProblemPreviewResponse;
 import org.kwakmunsu.haruhana.global.support.OffsetLimit;
 import org.kwakmunsu.haruhana.global.support.response.ApiResponse;
 import org.kwakmunsu.haruhana.global.support.response.PageResponse;

--- a/src/main/java/org/kwakmunsu/haruhana/global/config/AsyncConfig.java
+++ b/src/main/java/org/kwakmunsu/haruhana/global/config/AsyncConfig.java
@@ -3,11 +3,14 @@ package org.kwakmunsu.haruhana.global.config;
 import static org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME;
 
 import java.util.concurrent.Executor;
+import lombok.RequiredArgsConstructor;
 import org.kwakmunsu.haruhana.global.support.error.AsyncExceptionHandler;
 import org.kwakmunsu.haruhana.global.support.logging.MdcTaskDecorator;
+import org.kwakmunsu.haruhana.global.support.notification.ErrorNotificationSender;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -22,8 +25,12 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  * </ul>
  */
 @EnableAsync
+@RequiredArgsConstructor
 @Configuration
 public class AsyncConfig implements AsyncConfigurer {
+
+    @Lazy
+    private final ErrorNotificationSender errorNotificationSender;
 
     @Bean(name = APPLICATION_TASK_EXECUTOR_BEAN_NAME)
     public ThreadPoolTaskExecutor asyncTaskExecutor() {
@@ -45,7 +52,7 @@ public class AsyncConfig implements AsyncConfigurer {
 
     @Bean
     public AsyncExceptionHandler asyncExceptionHandler() {
-        return new AsyncExceptionHandler();
+        return new AsyncExceptionHandler(errorNotificationSender);
     }
 
     @Override

--- a/src/main/java/org/kwakmunsu/haruhana/global/support/error/AsyncExceptionHandler.java
+++ b/src/main/java/org/kwakmunsu/haruhana/global/support/error/AsyncExceptionHandler.java
@@ -1,7 +1,9 @@
 package org.kwakmunsu.haruhana.global.support.error;
 
 import java.lang.reflect.Method;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.kwakmunsu.haruhana.global.support.notification.ErrorNotificationSender;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.boot.logging.LogLevel;
 
@@ -12,7 +14,10 @@ import org.springframework.boot.logging.LogLevel;
  * AsyncConfig 에서 이 핸들러를 등록하여 사용합니다.
  */
 @Slf4j
+@RequiredArgsConstructor
 public class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+    private final ErrorNotificationSender errorNotificationSender;
 
     @Override
     public void handleUncaughtException(Throwable throwable, Method method, Object... params) {
@@ -25,17 +30,25 @@ public class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
             );
 
             switch (e.getErrorType().getLogLevel()) {
-                case LogLevel.ERROR -> log.error(logMessage, e);
+                case LogLevel.ERROR -> {
+                    log.error(logMessage, e);
+                    errorNotificationSender.sendErrorNotification(logMessage, e);
+                }
                 case LogLevel.WARN ->  log.warn(logMessage, e);
                 default ->             log.info(logMessage, e);
             }
         } else {
+            String logMessage = String.format("비동기 작업 중 Exception 발생 - Method: %s, Error: %s",
+                    method.getName(),
+                    throwable.getMessage()
+            );
             log.error("비동기 작업 중 Exception 발생 - Method: {}, Args: {}, Error: {}",
                     method.getName(),
                     params,
                     throwable.getMessage(),
                     throwable
             );
+            errorNotificationSender.sendErrorNotification(logMessage, throwable);
         }
     }
 

--- a/src/main/java/org/kwakmunsu/haruhana/global/support/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/kwakmunsu/haruhana/global/support/error/GlobalExceptionHandler.java
@@ -37,7 +37,7 @@ public class GlobalExceptionHandler {
 
         switch (errorType.getLogLevel()) {
             case LogLevel.ERROR -> {
-                log.error(logMessage);
+                log.error(logMessage, e);
                 errorNotificationSender.sendErrorNotification(logMessage, e);
             }
             case LogLevel.WARN ->  log.warn(logMessage);

--- a/src/main/java/org/kwakmunsu/haruhana/global/support/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/kwakmunsu/haruhana/global/support/error/GlobalExceptionHandler.java
@@ -4,7 +4,9 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import java.util.Map;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.kwakmunsu.haruhana.global.support.notification.ErrorNotificationSender;
 import org.kwakmunsu.haruhana.global.support.response.ApiResponse;
 import org.springframework.boot.logging.LogLevel;
 import org.springframework.http.ResponseEntity;
@@ -16,8 +18,11 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
+@RequiredArgsConstructor
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private final ErrorNotificationSender errorNotificationSender;
 
     @ExceptionHandler(HaruHanaException.class)
     public ResponseEntity<ApiResponse<?>> handleCustomException(HaruHanaException e) {
@@ -31,7 +36,10 @@ public class GlobalExceptionHandler {
         );
 
         switch (errorType.getLogLevel()) {
-            case LogLevel.ERROR -> log.error(logMessage);
+            case LogLevel.ERROR -> {
+                log.error(logMessage);
+                errorNotificationSender.sendErrorNotification(logMessage, e);
+            }
             case LogLevel.WARN ->  log.warn(logMessage);
             default ->             log.info(logMessage);
         }
@@ -44,6 +52,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
         log.error("[Exception]: {}", e.getMessage(), e);
+        errorNotificationSender.sendErrorNotification("[Exception]: " + e.getMessage(), e);
 
         ErrorType errorType = ErrorType.DEFAULT_ERROR;
 

--- a/src/main/java/org/kwakmunsu/haruhana/global/support/logging/MdcFilter.java
+++ b/src/main/java/org/kwakmunsu/haruhana/global/support/logging/MdcFilter.java
@@ -16,6 +16,10 @@ import org.springframework.web.filter.OncePerRequestFilter;
 /**
  * MDC(Mapped Diagnostic Context)에 요청 컨텍스트 정보를 설정하는 필터
  * - traceId: 요청 추적을 위한 ID
+ * - httpMethod: HTTP 메서드 (GET, POST 등)
+ * - requestUri: 요청 URI
+ * - queryString: 쿼리 파라미터
+ * - clientIp: 클라이언트 IP
  */
 @Slf4j
 @Component
@@ -23,6 +27,10 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class MdcFilter extends OncePerRequestFilter {
 
     private static final String TRACE_ID = "traceId";
+    private static final String HTTP_METHOD = "httpMethod";
+    private static final String REQUEST_URI = "requestUri";
+    private static final String QUERY_STRING = "queryString";
+    private static final String CLIENT_IP = "clientIp";
 
     @Override
     protected void doFilterInternal(
@@ -31,15 +39,25 @@ public class MdcFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
         try {
-            // Request ID와 Trace ID 생성
             String traceId = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
             MDC.put(TRACE_ID, traceId);
+            MDC.put(HTTP_METHOD, request.getMethod());
+            MDC.put(REQUEST_URI, request.getRequestURI());
+            MDC.put(QUERY_STRING, request.getQueryString() != null ? request.getQueryString() : "");
+            MDC.put(CLIENT_IP, resolveClientIp(request));
 
-            // 다음 필터 체인 실행
             filterChain.doFilter(request, response);
         } finally {
-            // MDC 클리어 (메모리 누수 방지)
             MDC.clear();
         }
     }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip != null && !ip.isBlank()) {
+            return ip.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+
 }

--- a/src/main/java/org/kwakmunsu/haruhana/global/support/notification/ErrorNotificationSender.java
+++ b/src/main/java/org/kwakmunsu/haruhana/global/support/notification/ErrorNotificationSender.java
@@ -1,0 +1,7 @@
+package org.kwakmunsu.haruhana.global.support.notification;
+
+public interface ErrorNotificationSender {
+
+    void sendErrorNotification(String message, Throwable throwable);
+
+}

--- a/src/main/java/org/kwakmunsu/haruhana/infrastructure/slack/SlackNotificationSender.java
+++ b/src/main/java/org/kwakmunsu/haruhana/infrastructure/slack/SlackNotificationSender.java
@@ -1,0 +1,100 @@
+package org.kwakmunsu.haruhana.infrastructure.slack;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.kwakmunsu.haruhana.global.support.notification.ErrorNotificationSender;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+public class SlackNotificationSender implements ErrorNotificationSender {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final int STACK_TRACE_LINES = 5;
+
+    @Value("${slack.webhook.url:}")
+    private String webhookUrl;
+
+    @Async
+    public void sendErrorNotification(String message, Throwable throwable) {
+        if (!StringUtils.hasText(webhookUrl)) {
+            return;
+        }
+
+        try {
+            String payload = buildPayload(message, throwable);
+            sendToSlack(payload);
+        } catch (Exception ex) {
+            log.warn("Slack 알림 전송 실패: {}", ex.getMessage());
+        }
+    }
+
+    private String buildPayload(String message, Throwable throwable) {
+        String time = LocalDateTime.now().format(FORMATTER);
+        String traceId = mdcOrDefault("traceId");
+        String httpMethod = mdcOrDefault("httpMethod");
+        String requestUri = mdcOrDefault("requestUri");
+        String queryString = MDC.get("queryString");
+        String clientIp = mdcOrDefault("clientIp");
+        String stackTrace = extractStackTrace(throwable);
+
+        String urlLine = queryString != null && !queryString.isBlank()
+                ? requestUri + "?" + queryString
+                : requestUri;
+
+        String text = String.format(
+                "🚨 *[ERROR] 서버 에러 발생*"
+                + "\\n• *시간*: %s"
+                + "\\n• *traceId*: %s"
+                + "\\n• *요청*: `%s %s`"
+                + "\\n• *클라이언트 IP*: %s"
+                + "\\n• *메세지*: %s"
+                + "\\n• *스택 트레이스*:\\n```\\n%s\\n```",
+                time, traceId, httpMethod, urlLine, clientIp, message, stackTrace
+        );
+
+        return "{\"text\": \"" + text + "\"}";
+    }
+
+    private String mdcOrDefault(String key) {
+        String value = MDC.get(key);
+        return value != null ? value : "N/A";
+    }
+
+    private String extractStackTrace(Throwable throwable) {
+        if (throwable == null) {
+            return "N/A";
+        }
+        return Arrays.stream(throwable.getStackTrace())
+                .limit(STACK_TRACE_LINES)
+                .map(StackTraceElement::toString)
+                .collect(Collectors.joining("\\n"));
+    }
+
+    private void sendToSlack(String payload) throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(webhookUrl))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(payload))
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 200) {
+            log.warn("Slack webhook 응답 오류: status={}, body={}", response.statusCode(), response.body());
+        }
+    }
+
+}

--- a/src/main/java/org/kwakmunsu/haruhana/infrastructure/slack/SlackNotificationSender.java
+++ b/src/main/java/org/kwakmunsu/haruhana/infrastructure/slack/SlackNotificationSender.java
@@ -1,13 +1,16 @@
 package org.kwakmunsu.haruhana.infrastructure.slack;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.kwakmunsu.haruhana.global.support.notification.ErrorNotificationSender;
@@ -22,7 +25,13 @@ import org.springframework.util.StringUtils;
 public class SlackNotificationSender implements ErrorNotificationSender {
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
     private static final int STACK_TRACE_LINES = 5;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    public static final String NA = "N/A";
+
 
     @Value("${slack.webhook.url:}")
     private String webhookUrl;
@@ -36,12 +45,15 @@ public class SlackNotificationSender implements ErrorNotificationSender {
         try {
             String payload = buildPayload(message, throwable);
             sendToSlack(payload);
-        } catch (Exception ex) {
-            log.warn("Slack 알림 전송 실패: {}", ex.getMessage());
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            log.warn("[SlackNotificationSender] Slack 알림 전송 중단 (인터럽트): {}", ex.getMessage());
+        } catch (IOException ex) {
+            log.warn("[SlackNotificationSender] Slack 알림 전송 실패: {}", ex.getMessage());
         }
     }
 
-    private String buildPayload(String message, Throwable throwable) {
+    private String buildPayload(String message, Throwable throwable) throws IOException {
         String time = LocalDateTime.now().format(FORMATTER);
         String traceId = mdcOrDefault("traceId");
         String httpMethod = mdcOrDefault("httpMethod");
@@ -54,46 +66,53 @@ public class SlackNotificationSender implements ErrorNotificationSender {
                 ? requestUri + "?" + queryString
                 : requestUri;
 
-        String text = String.format(
-                "🚨 *[ERROR] 서버 에러 발생*"
-                + "\\n• *시간*: %s"
-                + "\\n• *traceId*: %s"
-                + "\\n• *요청*: `%s %s`"
-                + "\\n• *클라이언트 IP*: %s"
-                + "\\n• *메세지*: %s"
-                + "\\n• *스택 트레이스*:\\n```\\n%s\\n```",
-                time, traceId, httpMethod, urlLine, clientIp, message, stackTrace
-        );
+        String text = """
+                🚨 *[ERROR] 서버 에러 발생*
+                • *시간*: %s
+                • *traceId*: %s
+                • *요청*: `%s %s`
+                • *클라이언트 IP*: %s
+                • *메세지*: %s
+                • *스택 트레이스*:
+                ```
+                %s
+                ```""".formatted(time, traceId, httpMethod, urlLine, clientIp, message, stackTrace);
 
-        return "{\"text\": \"" + text + "\"}";
+        // Jackson이 text 값의 특수문자(", \, 개행 등)를 자동으로 이스케이프
+        return OBJECT_MAPPER.writeValueAsString(Map.of("text", text));
     }
 
     private String mdcOrDefault(String key) {
         String value = MDC.get(key);
-        return value != null ? value : "N/A";
+
+        return value != null ? value : NA;
     }
 
     private String extractStackTrace(Throwable throwable) {
         if (throwable == null) {
-            return "N/A";
+            return NA;
         }
         return Arrays.stream(throwable.getStackTrace())
                 .limit(STACK_TRACE_LINES)
                 .map(StackTraceElement::toString)
-                .collect(Collectors.joining("\\n"));
+                .collect(Collectors.joining("\n"));
     }
 
     private void sendToSlack(String payload) throws IOException, InterruptedException {
-        HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(webhookUrl))
                 .header("Content-Type", "application/json")
+                .timeout(Duration.ofSeconds(10))
                 .POST(HttpRequest.BodyPublishers.ofString(payload))
                 .build();
 
-        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+
         if (response.statusCode() != 200) {
-            log.warn("Slack webhook 응답 오류: status={}, body={}", response.statusCode(), response.body());
+            log.warn("[SlackNotificationSender] Slack webhook 응답 오류: status={}, body={}",
+                    response.statusCode(),
+                    response.body()
+            );
         }
     }
 

--- a/src/test/java/org/kwakmunsu/haruhana/ControllerTestSupport.java
+++ b/src/test/java/org/kwakmunsu/haruhana/ControllerTestSupport.java
@@ -20,6 +20,7 @@ import org.kwakmunsu.haruhana.domain.storage.service.StorageService;
 import org.kwakmunsu.haruhana.domain.streak.controller.StreakController;
 import org.kwakmunsu.haruhana.domain.streak.service.StreakService;
 import org.kwakmunsu.haruhana.domain.submission.service.SubmissionService;
+import org.kwakmunsu.haruhana.global.support.notification.ErrorNotificationSender;
 import org.kwakmunsu.haruhana.security.TestSecurityConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -80,5 +81,8 @@ public abstract class ControllerTestSupport {
 
     @MockitoBean
     protected StorageService storageService;
+
+    @MockitoBean
+    protected ErrorNotificationSender errorNotificationSender;
 
 }

--- a/src/test/java/org/kwakmunsu/haruhana/infrastructure/slack/SlackNotificationRealSendTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/infrastructure/slack/SlackNotificationRealSendTest.java
@@ -1,0 +1,75 @@
+package org.kwakmunsu.haruhana.infrastructure.slack;
+
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.kwakmunsu.haruhana.global.support.notification.ErrorNotificationSender;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@Disabled
+@ActiveProfiles("test")
+@SpringBootTest
+class SlackNotificationRealSendTest{
+
+    @Autowired
+    private ErrorNotificationSender errorNotificationSender;
+
+
+    @AfterEach
+    void clearMdc() {
+        MDC.clear();
+    }
+
+    @Test
+    void 실제_전송_RuntimeException_발생_시_Slack_알림이_전송된다() {
+        MDC.put("traceId", "real-trace-001");
+        MDC.put("httpMethod", "POST");
+        MDC.put("requestUri", "/api/test/real");
+        MDC.put("clientIp", "192.168.0.1");
+
+        RuntimeException exception = new RuntimeException("실제 전송 테스트용 RuntimeException");
+
+        errorNotificationSender.sendErrorNotification("[실제 전송 테스트] RuntimeException 발생", exception);
+
+        // @Async로 비동기 실행되므로 전송 완료 대기
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+                .pollDelay(2, TimeUnit.SECONDS)
+                .until(() -> true);
+    }
+
+    @Test
+    void 실제_전송_queryString이_포함된_요청_정보가_Slack_알림에_표시된다() {
+        MDC.put("traceId", "real-trace-002");
+        MDC.put("httpMethod", "GET");
+        MDC.put("requestUri", "/api/problems");
+        MDC.put("queryString", "page=1&size=10&keyword=테스트");
+        MDC.put("clientIp", "10.0.0.1");
+
+        IllegalArgumentException exception = new IllegalArgumentException("잘못된 요청 파라미터");
+
+        errorNotificationSender.sendErrorNotification("[실제 전송 테스트] 쿼리스트링 포함 요청", exception);
+
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+                .pollDelay(2, TimeUnit.SECONDS)
+                .until(() -> true);
+    }
+
+    @Test
+    void 실제_전송_throwable이_null이어도_N_A로_정상_전송된다() {
+        MDC.put("traceId", "real-trace-003");
+        MDC.put("httpMethod", "DELETE");
+        MDC.put("requestUri", "/api/user/1");
+        MDC.put("clientIp", "172.16.0.5");
+
+        errorNotificationSender.sendErrorNotification("[실제 전송 테스트] throwable=null 케이스", null);
+
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+                .pollDelay(2, TimeUnit.SECONDS)
+                .until(() -> true);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`:  #151 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 한 줄 요약
Error 레벨 예외 발생 시 Slack으로 알림을 전송하도록 예외 처리 및 로깅/알림 인프라를 추가함

## 변경 내용
- Slack 알림 전송 인프라 추가
  - SlackNotificationSender 클래스 추가
    - ErrorNotificationSender 인터페이스 구현체로 slack.webhook.url 설정이 있으면 비동기(@Async)로 Slack webhook에 에러 메시지 전송
    - 전송 페이로드에 시간, traceId, HTTP 메서드, 요청 URI(쿼리 포함), 클라이언트 IP, 전달된 메시지, 최대 5줄의 스택트레이스 포함
    - 공유 HttpClient, ObjectMapper 사용, 커넥트/요청 타임아웃 적용, 응답 코드 검사 및 경고 로그
    - webhook 미설정 시 조용히 종료
- 알림 인터페이스
  - ErrorNotificationSender 인터페이스 추가: void sendErrorNotification(String message, Throwable throwable)
- 예외 처리 확장
  - GlobalExceptionHandler
    - HaruHanaException의 LogLevel.ERROR 및 일반 Exception 처리 경로에서 errorNotificationSender.sendErrorNotification 호출 추가
    - 기존의 응답 생성 로직과 로그 레벨 별 동작은 유지
  - AsyncExceptionHandler
    - @Async 메서드에서 발생한 예외 처리 시 Error 레벨인 경우 알림 전송 추가
    - 비-HaruHanaException의 경우에도 알림 전송 추가
- MDC(요청 컨텍스트) 보강
  - MdcFilter에서 MDC에 traceId 뿐만 아니라 httpMethod, requestUri, queryString, clientIp 추가
  - clientIp는 X-Forwarded-For 우선, 없으면 remoteAddr 사용
- 비동기 설정 변경
  - AsyncConfig가 ErrorNotificationSender를 주입받도록 수정하고 AsyncExceptionHandler에 주입
- 테스트 및 빌드 변경
  - build.gradle에 mockwebserver 의존성 추가 (테스트 용)
  - ControllerTestSupport에 @MockitoBean protected ErrorNotificationSender 추가(테스트에서 주입/모킹 용)
  - SlackNotificationRealSendTest 추가(Disabled 처리되어 실제 전송 테스트는 수동 실행용)

## 영향 범위
- 전역 예외 처리 흐름: GlobalExceptionHandler를 거치는 모든 예외(특히 ERROR 레벨)는 Slack 알림 대상이 됨
- 비동기 작업 오류 처리: @Async로 실행되는 작업에서 발생한 예외도 알림 전송 대상
- 로깅/모니터링: MDC에 추가된 httpMethod, requestUri, queryString, clientIp 값은 로그 및 Slack 페이로드에 포함되어 노출됨
- 테스트 인프라: 테스트 컨텍스트에 ErrorNotificationSender 모킹 필요, MockWebServer 의존성 추가

## 리뷰어 주목 포인트
- Slack webhook 보안/설정
  - webhook URL이 외부로 유출되면 민감 정보가 노출될 수 있음 — 설정 관리(시크릿 관리) 및 접근 제어 확인 필요
  - Slack으로 전송되는 페이로드에 요청 URI/쿼리/클라이언트 IP/스택트레이스 등이 포함되므로 개인정보(예: 쿼리파라미터로 전송되는 토큰 등) 노출 가능성 검토 필요
- 동기/비동기 처리 및 성능
  - SlackNotificationSender는 @Async로 호출하지만 내부에서 HttpClient.send(블로킹)를 사용. 동시성/스레드 풀이 급증할 경우 블로킹이 문제될 수 있음(논블로킹 전송 검토 권장).
  - HTTP 요청 타임아웃(연결 5s, 요청 10s) 및 InterruptedException 처리 로직은 존재하나, 전송 실패 시 재시도 정책이 없음 — 필요 시 재시도/백오프 고려.
- MDC 전파 및 정합성
  - MdcFilter에서 MDC를 설정 후 finally에서 MDC.clear() 함 — 비동기 전파(Async 작업)는 MdcTaskDecorator를 사용하지만, MDC 값이 없는 상황에서 Slack 알림의 기본값("N/A") 동작을 의도대로 처리하는지 확인 필요.
- 예외 정보의 양과 형식
  - 스택트레이스는 5줄로 제한되어 있음(설계 의도). 더 많은 정보가 필요할 경우 제한 완화 방안 검토.
- 테스트 커버리지
  - 실제 전송을 Disabled 상태의 통합 테스트로 남겨둠 — CI에서 실전 전송이 일어나지 않도록 의도된 것인지 확인 필요.
  - ControllerTestSupport에 ErrorNotificationSender 모킹이 추가되어 테스트에 미치는 영향(필요한 verify/설정 누락 여부) 검토 필요.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->