### PR TITLE
Feat: CORS 설정을 외부 설정 파일에서 읽어오도록 수정

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/global/security/jwt/config/SecurityConfig.java
+++ b/src/main/java/org/kwakmunsu/haruhana/global/security/jwt/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.kwakmunsu.haruhana.global.security.jwt.JwtAccessDeniedHandler;
 import org.kwakmunsu.haruhana.global.security.jwt.JwtAuthenticationEntryPoint;
 import org.kwakmunsu.haruhana.global.security.jwt.JwtFilter;
 import org.kwakmunsu.haruhana.global.security.jwt.JwtProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -24,13 +25,15 @@ import org.springframework.web.cors.CorsConfiguration;
 @Configuration
 public class SecurityConfig {
 
-    private static final List<String> ALLOWED_ORIGINS = List.of("http://localhost:5173", "https://haruharu.vercel.app");
     private static final List<String> ALLOWED_METHODS = List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS");
 
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
+
+    @Value("${cors.allowed-origins}")
+    private List<String> allowedOrigins;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -65,7 +68,7 @@ public class SecurityConfig {
                 .cors(
                         corsCustomizer -> corsCustomizer.configurationSource(request -> {
                             CorsConfiguration config = new CorsConfiguration();
-                            config.setAllowedOrigins(ALLOWED_ORIGINS);
+                            config.setAllowedOrigins(allowedOrigins);
                             config.setAllowedMethods(ALLOWED_METHODS);
                             config.setAllowedHeaders(List.of("*"));
                             config.setAllowCredentials(true);


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`: #158 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 한 줄 요약
CORS 설정의 허용 출처를 하드코딩된 상수에서 외부 설정 파일로 변경하여 환경별로 동적으로 관리할 수 있도록 개선함

## 변경 내용
- **SecurityConfig 클래스에 `@Value` 어노테이션 추가**: `@Value("${cors.allowed-origins}")` 어노테이션을 통해 `cors.allowed-origins` 속성값을 `allowedOrigins` 필드에 주입받도록 수정
- **CORS 허용 출처 설정 동적화**: 기존의 하드코딩된 `ALLOWED_ORIGINS` 상수 대신, 외부 설정에서 읽어온 `allowedOrigins` 리스트를 `config.setAllowedOrigins(allowedOrigins)`에 전달하여 환경별로 다른 CORS 정책을 적용할 수 있게 변경
- **CORS 메서드와 헤더 설정은 유지**: `ALLOWED_METHODS` 상수로 정의된 허용 메서드(GET, POST, PUT, PATCH, DELETE, OPTIONS)와 허용 헤더 설정은 기존대로 유지

## 영향 범위
- **모든 API 엔드포인트의 CORS 정책**: 프론트엔드에서 크로스 오리진 요청을 할 때 적용되는 CORS 필터
- **환경별 배포**: local, staging, prod 등 각 환경에서 서로 다른 CORS 허용 출처를 설정 가능
- **프론트엔드와의 통신**: 클라이언트 애플리케이션에서 백엔드 API 호출 시 출처 검증 로직에 영향

## 리뷰어 주목 포인트
- **설정 속성명 확인**: `cors.allowed-origins` 속성이 각 환경의 설정 파일(application-local.yml, application-staging.yml, application-prod.yml 등)에 정확히 정의되어 있는지 검증 필요
- **List 파싱 확인**: YAML 설정에서 쉼표로 구분된 문자열이나 리스트 형식으로 입력된 값이 `List<String>`으로 올바르게 파싱되는지 확인
- **기본값 처리**: 설정값이 누락된 경우의 동작 방식 확인 (NullPointerException 발생 가능성, @Value의 기본값 설정 여부)
- **보안 검증**: CORS 허용 출처 설정 실수로 인한 보안 취약점(예: 와일드카드 남용) 검증

<!-- end of auto-generated comment: release notes by coderabbit.ai -->