### PR TITLE
Fix: 수정된 actuator 엔드포인트 접근 권한 및 정책 정의 (#162)

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/global/security/jwt/config/SecurityConfig.java
+++ b/src/main/java/org/kwakmunsu/haruhana/global/security/jwt/config/SecurityConfig.java
@@ -50,9 +50,10 @@ public class SecurityConfig {
                         .requestMatchers("/v1/categories").permitAll()
                         .requestMatchers("/v1/auth/login", "/v1/auth/reissue").permitAll()
                         .requestMatchers("/v1/members/sign-up", "/v1/members/nickname", "/v1/members/login-id").permitAll()
-                        .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
+                        .requestMatchers("/actuator/**").denyAll()
                         .requestMatchers("/swagger/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/v1/admin/**", "/actuator/**").hasRole("ADMIN")
+                        .requestMatchers("/v1/admin/**").hasRole("ADMIN")
                         .anyRequest().hasAnyRole("MEMBER", "ADMIN")
                 );
 


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`: #161 

---

문제
Prometheus가 /actuator/prometheus를 30초마다 스크레이핑할 때
Spring Security의 ADMIN 권한 설정에 막혀 JwtAuthenticationEntryPoint에서
WARN 로그가 반복적으로 발생하고 있었음

원인
/actuator/** 경로 전체가 ADMIN 권한으로 설정되어 있어
/actuator/health, /actuator/info만 예외 처리되었고
/actuator/prometheus는 누락된 상태였음

해결
SecurityConfig: /actuator/prometheus를 permitAll()에 추가
nginx: /actuator 경로 외부 접근 차단 (내부 Docker 네트워크는 정상 접근 유지)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 한 줄 요약
Prometheus 모니터링 엔드포인트의 인증 차단 문제를 해결하기 위해 `/actuator/prometheus`를 인증 제외 목록에 추가하고 actuator 경로 접근 정책을 강화함

## 변경 내용

**SecurityConfig.java의 인증 정책 개선:**
- `/actuator/prometheus` 엔드포인트를 `permitAll()` 화이트리스트에 추가하여 인증 없이 접근 가능하도록 변경
  - 기존: `/actuator/health`, `/actuator/info`만 허용
  - 변경: `/actuator/health`, `/actuator/info`, `/actuator/prometheus` 모두 허용
- `/actuator/**` 경로 전체에 대해 `denyAll()` 정책 적용으로 화이트리스트에 명시되지 않은 모든 actuator 엔드포인트 접근을 차단
- `/v1/admin/**` 경로만 ADMIN 역할 요구로 범위를 좁혀 관리 부담 감소

## 영향 범위
- Prometheus 메트릭 수집: `/actuator/prometheus` 엔드포인트의 스크레이핑 성공 (30초마다 반복 시도 시 성공)
- 다른 actuator 엔드포인트: 화이트리스트에 없는 경로(예: `/actuator/env`, `/actuator/metrics` 등)는 모두 접근 거부
- Spring Security 로깅: JwtAuthenticationEntryPoint의 반복 WARN 로그 제거로 로그 클린업

## 리뷰어 주목 포인트
- **접근 제어 순서**: `permitAll()` 룰이 `denyAll()` 룰보다 먼저 정의되어 올바른 우선순위 유지 확인
- **보안 정책 일관성**: nginx 레벨 설정(외부 접근 차단, 내부 Docker 네트워크에서만 허용)과 Spring Security 설정이 일관되게 작동하는지 검증 필요
- **화이트리스트 누락 확인**: 향후 새로운 actuator 엔드포인트 추가 시 함께 등록되어야 함을 문서화할 필요

<!-- end of auto-generated comment: release notes by coderabbit.ai -->