### PR TITLE
 Fix: 회원 탈퇴 시 loginId와 nickname 익명화 처리

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/entity/Member.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/entity/Member.java
@@ -6,6 +6,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -85,6 +86,12 @@ public class Member extends BaseEntity {
 
     public boolean hasMatchingNickname(String nickname) {
         return this.nickname.equals(nickname);
+    }
+
+    public void anonymize() {
+        String suffix = this.getId() + "_" + UUID.randomUUID().toString().substring(0, 8);
+        this.loginId = "deleted_" + suffix;
+        this.nickname = "deleted_" + suffix;
     }
 
     public void validatePassword(PasswordEncoder passwordEncoder, String targetPassword) {

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberRemover.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberRemover.java
@@ -48,6 +48,7 @@ public class MemberRemover {
         // 2. 회원 엔티티 상태 변경 후 즉시 flush
         //    이후 bulk UPDATE 쿼리들이 영속성 컨텍스트를 초기화하기 때문에,
         //    member 변경 사항을 DB에 먼저 반영해야 한다.
+        member.anonymize();  // nickname, loginId 익명화 (unique 충돌 방지)
         member.clearRefreshToken();
         member.delete();
         memberJpaRepository.saveAndFlush(member);

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/entity/MemberTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/entity/MemberTest.java
@@ -1,0 +1,66 @@
+package org.kwakmunsu.haruhana.domain.member.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.kwakmunsu.haruhana.domain.member.MemberFixture;
+import org.kwakmunsu.haruhana.domain.member.enums.Role;
+
+class MemberTest {
+
+    @Test
+    void 익명화_시_loginId와_nickname이_deleted_형식으로_변경된다() {
+        // given
+        Member member = MemberFixture.createMember(Role.ROLE_MEMBER);
+
+        // when
+        member.anonymize();
+
+        // then
+        assertThat(member.getLoginId()).startsWith("deleted_");
+        assertThat(member.getNickname()).startsWith("deleted_");
+    }
+
+    @Test
+    void 익명화_후_loginId와_nickname은_동일한_값이다() {
+        // given
+        Member member = MemberFixture.createMember(Role.ROLE_MEMBER);
+
+        // when
+        member.anonymize();
+
+        // then
+        assertThat(member.getLoginId()).isEqualTo(member.getNickname());
+    }
+
+    @Test
+    void 익명화_시_기존_loginId와_nickname이_다른_값으로_변경된다() {
+        // given
+        Member member = MemberFixture.createMember(Role.ROLE_MEMBER);
+        String originalLoginId = member.getLoginId();
+        String originalNickname = member.getNickname();
+
+        // when
+        member.anonymize();
+
+        // then
+        assertThat(member.getLoginId()).isNotEqualTo(originalLoginId);
+        assertThat(member.getNickname()).isNotEqualTo(originalNickname);
+    }
+
+    @Test
+    void 익명화를_두_번_호출하면_다른_값이_생성된다() {
+        // given
+        Member member1 = MemberFixture.createMember(Role.ROLE_MEMBER);
+        Member member2 = MemberFixture.createMember(Role.ROLE_MEMBER);
+
+        // when
+        member1.anonymize();
+        member2.anonymize();
+
+        // then
+        assertThat(member1.getLoginId()).isNotEqualTo(member2.getLoginId());
+        assertThat(member1.getNickname()).isNotEqualTo(member2.getNickname());
+    }
+
+}

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberServiceIntegrationTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberServiceIntegrationTest.java
@@ -94,6 +94,49 @@ class MemberServiceIntegrationTest extends IntegrationTestSupport {
     }
 
     @Test
+    void 회원_탈퇴_시_loginId와_nickname이_익명화된다() {
+        // given
+        var newProfile = MemberFixture.createNewProfile();
+        var newPreference = new NewPreference(categoryTopic.getId(), ProblemDifficulty.EASY);
+        Long memberId = memberService.createMember(newProfile, newPreference);
+
+        // when
+        memberService.withdraw(memberId);
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        var withdrawnMember = memberJpaRepository.findById(memberId).orElseThrow();
+        assertThat(withdrawnMember.getLoginId()).startsWith("deleted_");
+        assertThat(withdrawnMember.getNickname()).startsWith("deleted_");
+        assertThat(withdrawnMember.getLoginId()).isNotEqualTo(MemberFixture.LOGIN_ID);
+        assertThat(withdrawnMember.getNickname()).isNotEqualTo(MemberFixture.NICKNAME);
+    }
+
+    @Test
+    void 탈퇴한_회원과_동일한_loginId와_nickname으로_재가입이_가능하다() {
+        // given - 첫 번째 회원 가입 후 탈퇴
+        var newProfile = MemberFixture.createNewProfile();
+        var newPreference = new NewPreference(categoryTopic.getId(), ProblemDifficulty.EASY);
+        Long firstMemberId = memberService.createMember(newProfile, newPreference);
+        memberService.withdraw(firstMemberId);
+        entityManager.flush();
+        entityManager.clear();
+
+        // when - 동일한 loginId, nickname으로 재가입
+        Long secondMemberId = memberService.createMember(newProfile, newPreference);
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        assertThat(secondMemberId).isNotEqualTo(firstMemberId);
+        var secondMember = memberJpaRepository.findById(secondMemberId).orElseThrow();
+        assertThat(secondMember.getLoginId()).isEqualTo(MemberFixture.LOGIN_ID);
+        assertThat(secondMember.getNickname()).isEqualTo(MemberFixture.NICKNAME);
+        assertThat(secondMember.getStatus()).isEqualTo(EntityStatus.ACTIVE);
+    }
+
+    @Test
     void 회원가입_시_회원_학습_설정과_스트릭_생성_문제_생성에_성공한다() {
         // given
         var newProfile = MemberFixture.createNewProfile();


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`: #169 


  ---
  ### Summary

  - 회원 탈퇴 시 loginId와 nickname을 deleted_{memberId}_{uuid8} 형식으로 익명화
  - soft delete 방식에서 UNIQUE 제약 조건으로 인해 탈퇴 후 동일 계정으로 재가입이 불가능했던 버그 수정

   ### Changes

  - Member.anonymize(): loginId, nickname을 deleted_{id}_{uuid8} 형식으로 덮어쓰는 메서드 추가
  - MemberRemover: 탈퇴 처리 순서 anonymize() → clearRefreshToken() → delete() → saveAndFlush() 로 변경
  - MemberTest: 단위 테스트 4건 추가 (형식 검증, 동일값 검증, 변경 검증, 고유성 검증)
  - MemberServiceIntegrationTest: 통합 테스트 2건 추가 (익명화 확인, 탈퇴 후 동일 계정 재가입 가능 확인)

   ### Test plan

  - 회원 탈퇴 시 loginId, nickname이 deleted_ 접두사로 변경되는지 확인
  - 탈퇴 후 동일 loginId/nickname으로 재가입 가능한지 확인
  - MemberTest 단위 테스트 4건 통과
  - MemberServiceIntegrationTest 통합 테스트 2건 통과
---