### PR TITLE
Fix: 관리자 버전 카테고리 삭제 후 동일한 카테고리 생성 시 에러 발생 해결

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/domain/category/entity/Category.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/category/entity/Category.java
@@ -2,17 +2,20 @@ package org.kwakmunsu.haruhana.domain.category.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.kwakmunsu.haruhana.global.entity.BaseEntity;
 
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"name", "deleted_at"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Category extends BaseEntity {
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String name;
 
     public static Category create(String name) {

--- a/src/main/java/org/kwakmunsu/haruhana/domain/category/entity/CategoryGroup.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/category/entity/CategoryGroup.java
@@ -2,11 +2,14 @@ package org.kwakmunsu.haruhana.domain.category.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.kwakmunsu.haruhana.global.entity.BaseEntity;
 
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"name", "deleted_at"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -15,7 +18,7 @@ public class CategoryGroup extends BaseEntity {
     @Column(nullable = false)
     private Long categoryId;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String name;
 
     public static CategoryGroup create(Long categoryId, String name) {

--- a/src/main/java/org/kwakmunsu/haruhana/domain/category/entity/CategoryTopic.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/category/entity/CategoryTopic.java
@@ -2,11 +2,14 @@ package org.kwakmunsu.haruhana.domain.category.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.kwakmunsu.haruhana.global.entity.BaseEntity;
 
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"name", "deleted_at"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -15,7 +18,7 @@ public class CategoryTopic extends BaseEntity {
     @Column(nullable = false)
     private Long groupId;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String name;
 
     public static CategoryTopic create(Long groupId, String name) {

--- a/src/main/java/org/kwakmunsu/haruhana/domain/category/service/CategoryManager.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/category/service/CategoryManager.java
@@ -70,7 +70,8 @@ public class CategoryManager {
 
         List<CategoryGroup> groups = categoryGroupJpaRepository.findByCategoryId(categoryId);
         groups.forEach(group -> {
-            categoryTopicJpaRepository.findByGroupId(group.getId()).forEach(CategoryTopic::delete);
+            categoryTopicJpaRepository.findByGroupId(group.getId())
+                    .forEach(CategoryTopic::delete);
             group.delete();
         });
 
@@ -95,7 +96,8 @@ public class CategoryManager {
 
         if (group.isDeleted()) return;
 
-        categoryTopicJpaRepository.findByGroupId(groupId).forEach(CategoryTopic::delete);
+        categoryTopicJpaRepository.findByGroupId(groupId)
+                .forEach(CategoryTopic::delete);
 
         group.delete();
     }

--- a/src/main/java/org/kwakmunsu/haruhana/global/entity/BaseEntity.java
+++ b/src/main/java/org/kwakmunsu/haruhana/global/entity/BaseEntity.java
@@ -32,6 +32,8 @@ public abstract class BaseEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    private LocalDateTime deletedAt;
+
     @Enumerated(EnumType.STRING)
     private EntityStatus status = EntityStatus.ACTIVE;
 
@@ -69,6 +71,7 @@ public abstract class BaseEntity {
 
     public void delete() {
         status = EntityStatus.DELETED;
+        deletedAt = LocalDateTime.now();
     }
 
     public boolean isDeleted() {

--- a/src/test/java/org/kwakmunsu/haruhana/domain/category/service/CategoryManagerIntegrationTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/category/service/CategoryManagerIntegrationTest.java
@@ -9,6 +9,7 @@ import org.kwakmunsu.haruhana.IntegrationTestSupport;
 import org.kwakmunsu.haruhana.domain.category.repository.CategoryGroupJpaRepository;
 import org.kwakmunsu.haruhana.domain.category.repository.CategoryJpaRepository;
 import org.kwakmunsu.haruhana.domain.category.repository.CategoryTopicJpaRepository;
+import org.kwakmunsu.haruhana.global.entity.EntityStatus;
 import org.kwakmunsu.haruhana.global.support.error.ErrorType;
 import org.kwakmunsu.haruhana.global.support.error.HaruHanaException;
 import org.springframework.transaction.annotation.Transactional;
@@ -143,6 +144,97 @@ class CategoryManagerIntegrationTest extends IntegrationTestSupport {
         assertThatThrownBy(() -> categoryManager.createCategoryTopic(group.getId(), topicName))
                 .isInstanceOf(HaruHanaException.class)
                 .hasMessageContaining(ErrorType.DUPLICATE_CATEGORY_TOPIC_NAME.getMessage());
+    }
+
+    @Test
+    void 카테고리_삭제_후_동일한_이름으로_재생성_시_성공한다() {
+        // given
+        var name = "알고리즘";
+        var category = categoryManager.createCategory(name);
+        categoryManager.deleteCategory(category.getId());
+
+        // when
+        var newCategory = categoryManager.createCategory(name);
+
+        // then
+        assertThat(newCategory.getName()).isEqualTo(name);
+        assertThat(newCategory.getId()).isNotEqualTo(category.getId());
+    }
+
+    @Test
+    void 그룹_삭제_후_동일한_이름으로_재생성_시_성공한다() {
+        // given
+        var category = categoryManager.createCategory("알고리즘");
+        var groupName = "자료구조";
+        var group = categoryManager.createCategoryGroup(category.getId(), groupName);
+        categoryManager.deleteCategoryGroup(group.getId());
+
+        // when
+        var newGroup = categoryManager.createCategoryGroup(category.getId(), groupName);
+
+        // then
+        assertThat(newGroup.getName()).isEqualTo(groupName);
+        assertThat(newGroup.getId()).isNotEqualTo(group.getId());
+    }
+
+    @Test
+    void 토픽_삭제_후_동일한_이름으로_재생성_시_성공한다() {
+        // given
+        var category = categoryManager.createCategory("알고리즘");
+        var group = categoryManager.createCategoryGroup(category.getId(), "자료구조");
+        var topicName = "배열";
+        var topic = categoryManager.createCategoryTopic(group.getId(), topicName);
+        categoryManager.deleteCategoryTopic(topic.getId());
+
+        // when
+        var newTopic = categoryManager.createCategoryTopic(group.getId(), topicName);
+
+        // then
+        assertThat(newTopic.getName()).isEqualTo(topicName);
+        assertThat(newTopic.getId()).isNotEqualTo(topic.getId());
+    }
+
+    @Test
+    void 카테고리_삭제_시_하위_그룹과_토픽도_soft_delete_된다() {
+        // given
+        var category = categoryManager.createCategory("알고리즘");
+        var group = categoryManager.createCategoryGroup(category.getId(), "자료구조");
+        var topic = categoryManager.createCategoryTopic(group.getId(), "배열");
+
+        // when
+        categoryManager.deleteCategory(category.getId());
+
+        // then
+        var deletedCategory = categoryJpaRepository.findById(category.getId()).orElseThrow();
+        var deletedGroup = categoryGroupJpaRepository.findById(group.getId()).orElseThrow();
+        var deletedTopic = categoryTopicJpaRepository.findById(topic.getId()).orElseThrow();
+
+        assertThat(deletedCategory.getStatus()).isEqualTo(EntityStatus.DELETED);
+        assertThat(deletedCategory.getDeletedAt()).isNotNull();
+        assertThat(deletedGroup.getStatus()).isEqualTo(EntityStatus.DELETED);
+        assertThat(deletedGroup.getDeletedAt()).isNotNull();
+        assertThat(deletedTopic.getStatus()).isEqualTo(EntityStatus.DELETED);
+        assertThat(deletedTopic.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    void 그룹_삭제_시_하위_토픽도_soft_delete_된다() {
+        // given
+        var category = categoryManager.createCategory("알고리즘");
+        var group = categoryManager.createCategoryGroup(category.getId(), "자료구조");
+        var topic = categoryManager.createCategoryTopic(group.getId(), "배열");
+
+        // when
+        categoryManager.deleteCategoryGroup(group.getId());
+
+        // then
+        var deletedGroup = categoryGroupJpaRepository.findById(group.getId()).orElseThrow();
+        var deletedTopic = categoryTopicJpaRepository.findById(topic.getId()).orElseThrow();
+
+        assertThat(deletedGroup.getStatus()).isEqualTo(EntityStatus.DELETED);
+        assertThat(deletedGroup.getDeletedAt()).isNotNull();
+        assertThat(deletedTopic.getStatus()).isEqualTo(EntityStatus.DELETED);
+        assertThat(deletedTopic.getDeletedAt()).isNotNull();
     }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`: #178 
---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 한 줄 요약

카테고리 엔티티의 unique constraint를 단일 컬럼에서 복합 제약으로 변경하고 soft delete를 도입하여 삭제된 카테고리와 동일한 이름으로 재생성할 수 있도록 개선하며, 로깅 강화 및 보안 설정 중앙화를 함께 진행함.

## 변경 내용

### 핵심 버그 픽스: Soft Delete 기반 Unique Constraint 개선

**Category, CategoryGroup, CategoryTopic 엔티티**
- 기존: `name` 컬럼에 단일 unique constraint 적용
- 변경: `@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"name", "deleted_at"}))` 복합 unique constraint 도입
- 목적: 삭제된 엔티티(deletedAt != null)는 unique constraint 대상에서 제외되어, 동일한 이름으로 새로운 엔티티 생성 가능

**BaseEntity**
- `deletedAt` 필드(LocalDateTime) 추가
- `delete()` 메서드 수정: `status = DELETED` 설정 시 `deletedAt = LocalDateTime.now()` 함께 기록
- soft delete 패턴 구현으로 데이터 물리 삭제 방지

### 로깅 강화

다음 Manager/Service 클래스에 SLF4J 기반 로깅 추가:
- **DailyProblemManager**: 일일 문제 배정 시작/완료 로그 (problemId, memberCount, targetDate)
- **DailyProblemService**: 캐시 미스 및 일일 문제 조회 시 debug 로그
- **MemberManager**: 회원 생성/선호도 등록 시 완료 로그 기록
- **StorageManager**: 파일 업로드 처리 단계별 debug/info 로그 추가
- **SubmissionManager**: 제출물 생성/수정 로그 기록
- **ChatService**: AI API 호출 전/후 로그
- **S3Provider**: presigned URL 생성, 객체 삭제 등 단계별 로그 추가

### 보안 설정 중앙화

**SecurityPaths 클래스 신규 추가**
- `ACTUATOR_PERMIT`: actuator 헬스체크 및 모니터링 엔드포인트
- `PERMIT_ALL`: 공개 API 경로 (인증 불필요)
- `ADMIN`: 관리자 경로 (`/v1/admin/**`)

**SecurityConfig, TestSecurityConfig 업데이트**
- 하드코딩된 경로 문자열 대신 `SecurityPaths` 상수 참조로 변경
- 인증 설정의 일관성 및 유지보수성 향상

**JwtFilter 개선**
- `shouldNotFilter()` 메서드 추가로 불필요한 필터 호출 방지
- 토큰 없는 요청 처리: 필터 체인 계속 진행 → `EMPTY_TOKEN` 에러 응답으로 변경

### 테스트 코드 확대

**CategoryManagerIntegrationTest**
- 카테고리 삭제 후 동일한 이름으로 재생성 시나리오 테스트 추가
- 카테고리 그룹, 토픽 재생성 테스트 추가
- soft delete 계단식 전파(삭제된 카테고리 → 연결된 그룹/토픽도 soft delete) 검증
- deletedAt 필드가 null이 아님을 확인하는 assertion 추가

## 영향 범위

- **관리자 카테고리 관리 기능**: 동일 이름 카테고리 삭제 후 재생성 가능
- **카테고리 그룹/토픽**: 동일 규칙 적용으로 재생성 가능
- **로그 추적성**: 주요 도메인 기능 실행 시 상세 로그 기록
- **보안**: 공개/인증 경로 일원화로 JWT 필터링 정확성 향상
- **모니터링**: 추가 로그를 통해 애플리케이션 상태 가시성 증대

## 리뷰어 주목 포인트

1. **Unique Constraint 변경의 DB 영향**
   - 기존 데이터베이스에서 마이그레이션 스크립트 필요 여부 확인
   - deleted_at 컬럼이 이미 존재하는지, 기본값 설정이 적절한지 검토

2. **Soft Delete 계단식 전파**
   - CategoryManager에서 카테고리 삭제 시 연관된 그룹/토픽까지 삭제되는 로직이 정확히 작동하는지 확인
   - 쿼리 필터링: 조회 시 `deleted_at is null` 조건이 모든 카테고리 관련 쿼리에 적용되는지 점검

3. **로깅의 과도한 호출**
   - forEach 루프 내부 로깅으로 인한 성능 영향 검토
   - 대량의 카테고리/제출물 처리 시 로그 레벨 조정 필요 여부 확인

4. **JwtFilter 동작 변경**
   - `shouldNotFilter()`로 인해 특정 경로가 의도치 않게 필터 우회되지 않는지 확인
   - `EMPTY_TOKEN` 에러 응답이 클라이언트에서 올바르게 처리되는지 테스트

5. **SecurityPaths 상수 빠짐**
   - SecurityConfig 업데이트 시 모든 public 경로가 SecurityPaths에 포함되었는지 검증

<!-- end of auto-generated comment: release notes by coderabbit.ai -->