### PR TITLE
Fix: Prometheus 스크래핑 요청에 JwtFilter 적용되어 WARN 로그 발생 해결

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/global/security/jwt/JwtFilter.java
+++ b/src/main/java/org/kwakmunsu/haruhana/global/security/jwt/JwtFilter.java
@@ -33,8 +33,8 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
-        return Arrays.stream(SecurityPaths.PERMIT_ALL)
-                .anyMatch(path::startsWith);
+        return Arrays.stream(SecurityPaths.PERMIT_ALL).anyMatch(path::startsWith)
+                || Arrays.stream(SecurityPaths.ACTUATOR_PERMIT).anyMatch(path::equals);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- `/actuator/prometheus` 요청 시 JwtFilter가 실행되어 30초마다 `JWT 토큰이 존재하지 않습니다` WARN 로그 발생
- `shouldNotFilter`에 `ACTUATOR_PERMIT` 경로 추가하여 해당 요청은 JWT 필터를 건너뛰도록 수정

## Test plan
- [x] 배포 후 30초 간격 WARN 로그 미발생 확인
- [ ] `/actuator/prometheus` Prometheus 스크래핑 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 한 줄 요약
JwtFilter에서 ACTUATOR_PERMIT 경로 필터링을 추가하여 Prometheus 스크래핑 요청이 JWT 검증을 건너뛸 수 있도록 수정함

## 변경 내용
- **JwtFilter의 shouldNotFilter 메소드 수정**: 
  - 기존: PERMIT_ALL 경로만 필터를 건너뜀 (startsWith로 접두사 매칭)
  - 변경: ACTUATOR_PERMIT 경로도 필터를 건너뜀 (equals로 정확한 경로 매칭)
  - 이를 통해 `/actuator/prometheus`, `/actuator/health`, `/actuator/info` 요청이 JWT 토큰 검증 없이 처리됨

## 영향 범위
- Actuator 엔드포인트 (`/actuator/prometheus`, `/actuator/health`, `/actuator/info`)
- Prometheus 메트릭 수집 (30초 주기 스크래핑)
- JWT 필터 로직

## 리뷰어 주목 포인트
- **경로 매칭 방식의 차이**: PERMIT_ALL은 `startsWith` (접두사 매칭)를 사용하고 ACTUATOR_PERMIT은 `equals` (정확한 일치)를 사용함. 이는 의도적인 설계이므로 하위 경로 접근 시나리오를 고려했는지 확인 필요
- **보안 의도 검토**: `/actuator/prometheus` 등이 JWT 검증 없이 노출되어도 되는지 확인 (내부 모니터링만 허용하는 경우 보안그룹/방화벽으로 제어되는지 확인 권장)
- **SecurityPaths.ACTUATOR_PERMIT 배열 정의**: 예상된 경로가 정확하게 포함되어 있는지 확인 (특히 `/actuator/prometheus` 존재 여부)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->