### PR TITLE
Fix: nginx 컨테이너 기동 실패 - conf.d 마운트 경로 수정

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -20,7 +20,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./nginx/prod.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/prod.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/static:/etc/nginx/static:ro
       - /etc/letsencrypt/live:/etc/letsencrypt/live:ro
       - /etc/letsencrypt/archive:/etc/letsencrypt/archive:ro


### PR DESCRIPTION
## 원인
`prod.conf`는 `events {}`와 `http {}` 블록을 포함한 완전한 nginx 설정 파일인데,
`/etc/nginx/conf.d/default.conf`로 마운트되어 아래 오류 발생:
```
"events" directive is not allowed here in /etc/nginx/conf.d/default.conf:1
```
`conf.d/` 디렉토리는 메인 `nginx.conf`의 `http {}` 안에 include되는 위치이므로 `events {}`나 `http {}` 블록을 사용할 수 없음.

## 수정
```diff
- ./nginx/prod.conf:/etc/nginx/conf.d/default.conf:ro
+ ./nginx/prod.conf:/etc/nginx/nginx.conf:ro
```

## 테스트 플랜
- [ ] EC2에서 `docker compose -f docker-compose-prod.yml up -d` 실행 후 nginx 컨테이너 정상 기동 확인
- [ ] `https://api.haruharu.online/health` 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 한 줄 요약
docker-compose-prod.yml에서 nginx 컨테이너 설정 파일의 마운트 경로를 `/etc/nginx/conf.d/default.conf`에서 `/etc/nginx/nginx.conf`로 수정하여 컨테이너 기동 실패를 해결함

## 변경 내용

**docker-compose-prod.yml 수정**
- nginx 서비스의 volumes 설정에서 prod.conf 마운트 경로 변경
  - 변경 전: `./nginx/prod.conf:/etc/nginx/conf.d/default.conf:ro`
  - 변경 후: `./nginx/prod.conf:/etc/nginx/nginx.conf:ro`

**문제의 원인**
- prod.conf는 nginx의 `events {}` 블록과 `http {}` 블록을 포함한 완전한 nginx 설정 파일
- 이전 마운트 경로인 `/etc/nginx/conf.d/default.conf`는 메인 nginx.conf의 `http {}` 블록 내에 include되는 위치로, `events` 지시어나 `http` 블록을 포함할 수 없음
- 이로 인해 "events directive is not allowed here in /etc/nginx/conf.d/default.conf:1" 오류 발생

**해결 방식**
- prod.conf를 메인 설정 파일로서 `/etc/nginx/nginx.conf`에 직접 마운트하여 완전한 nginx 설정 구조 구현 가능

## 영향 범위
- 운영 환경(production) nginx 컨테이너의 기동 및 리버스 프록시 동작
- 도메인 `https://api.haruharu.online/health` 및 기타 모든 nginx를 통한 요청 처리
- docker-compose-prod.yml을 사용하는 모든 배포 프로세스

## 리뷰어 주목 포인트
- nginx 설정 파일 마운트 경로 변경이 실제 prod.conf의 구조(events, http 블록 포함)와 일치하는지 확인
- 스테이징 환경(docker-compose-staging.yml)에서는 여전히 `/etc/nginx/conf.d/default.conf`를 사용 중인지 확인 (staging.conf는 다른 구조를 가질 수 있음)
- 배포 후 EC2 환경에서 실제로 nginx 컨테이너가 정상 기동되고 헬스체크 엔드포인트가 응답하는지 테스트 필요

<!-- end of auto-generated comment: release notes by coderabbit.ai -->