### PR TITLE
Feat: FCM 알림 발송 실패 시 오류 알림 전송 기능 추가

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/domain/scheduler/NotificationScheduler.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/scheduler/NotificationScheduler.java
@@ -28,22 +28,18 @@ public class NotificationScheduler {
      * 매일 21시, 오늘 문제를 풀지 않은 회원들에게 푸시 알림을 전송합니다.
      */
     // NOTE: 추후 성능 이슈 발생 시, bulk send 또는 Async 처리 고려
-    @Scheduled(cron = "0 0 21 * * ?", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 21 * * ?")
     public void notifyUnsolvedProblemMembers() {
         log.info("[NotificationScheduler] 일일 문제 미풀이 회원 알림 전송 시작");
 
         try {
-            LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+            LocalDate today = LocalDate.now();
             List<String> deviceTokens = getUnsolvedMemberDeviceTokens(today);
 
             sendBulkNotifications(deviceTokens);
-
-            log.info("[NotificationScheduler] 알림 전송 완료: {}명", deviceTokens.size());
         } catch (Exception e) {
             log.error("[NotificationScheduler] 알림 전송 스케줄러 실행 중 예기치 않은 오류 발생", e);
-            errorNotificationSender.sendErrorNotification(
-                    "[NotificationScheduler] 알림 전송 스케줄러 실행 중 예기치 않은 오류 발생: " + e.getMessage(), e
-            );
+            errorNotificationSender.sendErrorNotification("[NotificationScheduler] 알림 전송 스케줄러 실행 중 예기치 않은 오류 발생: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/org/kwakmunsu/haruhana/infrastructure/firebase/FcmNotificationSender.java
+++ b/src/main/java/org/kwakmunsu/haruhana/infrastructure/firebase/FcmNotificationSender.java
@@ -7,6 +7,7 @@ import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.kwakmunsu.haruhana.domain.notification.enums.NotificationType;
+import org.kwakmunsu.haruhana.global.support.notification.ErrorNotificationSender;
 import org.kwakmunsu.haruhana.global.support.notification.NotificationSender;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Component;
 public class FcmNotificationSender implements NotificationSender {
 
     private final FirebaseMessaging firebaseMessaging;
+    private final ErrorNotificationSender errorNotificationSender;
 
     @Override
     public void sendNotification(String fcmToken, String title, String body, NotificationType type) {
@@ -35,6 +37,7 @@ public class FcmNotificationSender implements NotificationSender {
             log.info("[FcmNotificationSender] 알림 발송 성공. messageId: {}, type: {}", response, type);
         } catch (FirebaseMessagingException e) {
             log.error("[FcmNotificationSender] 알림 발송 실패. type: {}", type, e);
+            errorNotificationSender.sendErrorNotification("[FcmNotificationSender] 알림 발송 실패. type: " + type + ", error: " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`: #187 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 한 줄 요약
FCM 알림 발송 실패 시 오류 알림을 Slack으로 전송하는 기능을 추가하고, 스케줄러의 예외 처리를 개선함

## 변경 내용

**FcmNotificationSender.java**
- `ErrorNotificationSender` 의존성 추가: 생성자에 `errorNotificationSender` 파라미터 추가
- FCM 발송 실패 처리 강화: `FirebaseMessagingException` 발생 시 로그 기록에 더해 `errorNotificationSender.sendErrorNotification()`을 호출하여 Slack을 통한 오류 알림 전송
- 오류 알림 메시지에는 알림 타입과 상세 에러 메시지 포함

**NotificationScheduler.java**
- `ErrorNotificationSender` 의존성 추가: 생성자에 `errorNotificationSender` 파라미터 추가
- 예외 처리 개선: 스케줄러 실행 중 예외 발생 시 에러 로그 기록과 함께 `errorNotificationSender.sendErrorNotification()` 호출
- 타임존 처리 변경: `LocalDate.now(ZoneId.of("Asia/Seoul"))`를 `LocalDate.now()`로 단순화 (시스템 기본 타임존 사용)
- @Scheduled 어노테이션에서 명시적 타임존 설정 제거 (zone = "Asia/Seoul" 제거)

**테스트 코드 (NotificationSchedulerUnitTest.java)**
- 예외 발생 시 `errorNotificationSender.sendErrorNotification()`이 호출되는지 검증하는 테스트 케이스 포함 (2개 케이스)

## 영향 범위

- **FCM 알림 발송**: `FcmNotificationSender`를 통해 발송되는 모든 알림의 실패 케이스에서 Slack 오류 알림이 추가로 전송됨
- **일일 스케줄러 기능**: `NotificationScheduler`의 일일 미풀이 문제 알림 발송 시 예외 발생 시 Slack 오류 알림 전송
- **운영 모니터링**: 알림 발송 실패 사항이 Slack을 통해 실시간으로 감지 가능하게 됨

## 리뷰어 주목 포인트

- **에러 핸들링의 이중화**: FCM 발송 실패 시 로그와 Slack 알림이 함께 발생하므로, 동일한 에러에 대한 중복 알림이 발생하지 않도록 Slack 구성 확인 필요
- **타임존 변경의 영향**: `LocalDate.now()` 변경으로 인해 시스템 기본 타임존이 적용됨. 서버의 타임존이 "Asia/Seoul"로 설정되어 있는지 확인 필요
- **비동기 실행 보장**: `SlackNotificationSender`의 `sendErrorNotification()`은 `@Async`로 구현되어 있으므로, 에러 알림 전송이 비동기로 처리되어 메인 로직 지연 없음을 확인
- **Throwable 파라미터 null 가능성**: 두 곳 모두 `sendErrorNotification()`의 두 번째 파라미터로 예외를 전달하고 있으며, `SlackNotificationSender`는 null 처리를 지원하므로 안정성 있음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->