### PR TITLE
Refactor: 최근 출제된 문제 제목을 포함하여 중복 방지 프롬프트 생성 로직 개선

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/domain/problem/repository/ProblemJpaRepository.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/problem/repository/ProblemJpaRepository.java
@@ -12,10 +12,39 @@ import org.springframework.data.repository.query.Param;
 
 public interface ProblemJpaRepository extends JpaRepository<Problem, Long> {
 
-    Optional<Problem> findFirstByCategoryTopicIdAndDifficultyAndStatusOrderByProblemAtDesc(
-            Long categoryTopicId,
-            ProblemDifficulty difficulty,
-            EntityStatus status
+    // NOTE: LIMIT 1 is Hibernate 6.x JPQL extension - used intentionally
+    @Query("""
+            SELECT p FROM Problem p
+            WHERE p.categoryTopic.id = :categoryTopicId
+              AND p.difficulty = :difficulty
+              AND p.status = :status
+            ORDER BY (
+                SELECT MAX(dp.assignedAt)
+                FROM DailyProblem dp
+                WHERE dp.problem.id = p.id
+                  AND dp.status = :status
+            ) ASC NULLS FIRST
+            LIMIT 1
+            """)
+    Optional<Problem> findLeastRecentlyAssignedProblem(
+            @Param("categoryTopicId") Long categoryTopicId,
+            @Param("difficulty") ProblemDifficulty difficulty,
+            @Param("status") EntityStatus status
+    );
+
+    @Query("""
+            SELECT p.title FROM Problem p
+            WHERE p.categoryTopic.id = :categoryTopicId
+              AND p.difficulty = :difficulty
+              AND p.status = :status
+              AND p.problemAt >= :since
+            ORDER BY p.problemAt DESC
+            """)
+    List<String> findRecentTitlesByCategoryTopicIdAndDifficulty(
+            @Param("categoryTopicId") Long categoryTopicId,
+            @Param("difficulty") ProblemDifficulty difficulty,
+            @Param("status") EntityStatus status,
+            @Param("since") LocalDate since
     );
 
     // NOTE: LIMIT :limit OFFSET :offset는 표준 JPQL 문법이 아님.  "Hibernate 6.x 환경엔 작동함으로 의도적으로 사용"

--- a/src/main/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGenerator.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGenerator.java
@@ -30,6 +30,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class ProblemGenerator {
 
+    private static final int RECENT_DAYS_LIMIT = 30;
+
     private final MemberReader memberReader;
     private final ChatService chatService;
     private final ProblemJpaRepository problemJpaRepository;
@@ -140,7 +142,14 @@ public class ProblemGenerator {
     private Problem generateAndSaveProblem(ProblemGenerationGroup group, LocalDate problemAt) {
         ProblemGenerationKey key = group.key();
 
-        ProblemResponse problemResponse = getProblemToAi(key.categoryTopicName(), key.difficulty());
+        List<String> recentTitles = problemJpaRepository.findRecentTitlesByCategoryTopicIdAndDifficulty(
+                key.categoryTopicId(),
+                key.difficulty(),
+                EntityStatus.ACTIVE,
+                problemAt.minusDays(RECENT_DAYS_LIMIT)
+        );
+
+        ProblemResponse problemResponse = getProblemToAi(key.categoryTopicName(), key.difficulty(), recentTitles);
         validateProblemResponse(problemResponse);
 
         Problem saved = problemJpaRepository.save(Problem.create(
@@ -168,6 +177,12 @@ public class ProblemGenerator {
         return chatService.sendPrompt(prompt, ProblemResponse.class);
     }
 
+    private ProblemResponse getProblemToAi(String categoryTopicName, ProblemDifficulty difficulty, List<String> recentTitles) {
+        String prompt = Prompt.V2_PROMPT.generate(categoryTopicName, difficulty, recentTitles);
+
+        return chatService.sendPrompt(prompt, ProblemResponse.class);
+    }
+
     private void assignBackupProblem(
             Long categoryTopicId,
             String categoryTopicName,
@@ -175,10 +190,8 @@ public class ProblemGenerator {
             List<Member> members,
             LocalDate targetDate
     ) {
-        problemJpaRepository.findFirstByCategoryTopicIdAndDifficultyAndStatusOrderByProblemAtDesc(categoryTopicId,
-                difficulty,
-                EntityStatus.ACTIVE
-        ).ifPresentOrElse(backup -> {
+        problemJpaRepository.findLeastRecentlyAssignedProblem(categoryTopicId, difficulty, EntityStatus.ACTIVE)
+                .ifPresentOrElse(backup -> {
                     dailyProblemManager.assignDailyProblemToMembers(backup, members, targetDate);
                     log.info("[ProblemGenerator] 백업 문제 할당 완료 - 카테고리: {}, 난이도: {}, 회원 수: {}", categoryTopicName, difficulty, members.size());
                 },

--- a/src/main/java/org/kwakmunsu/haruhana/domain/problem/service/Prompt.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/problem/service/Prompt.java
@@ -1,5 +1,7 @@
 package org.kwakmunsu.haruhana.domain.problem.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.kwakmunsu.haruhana.domain.problem.enums.ProblemDifficulty;
@@ -127,6 +129,22 @@ public enum Prompt {
         return template
                 .replace("{category}", categoryName)
                 .replace("{difficulty}", translateDifficulty(difficulty));
+    }
+
+    /**
+     * 카테고리와 난이도를 주입하고, 최근 출제된 문제 제목을 포함하여 중복 방지 프롬프트 생성
+     */
+    public String generate(String categoryName, ProblemDifficulty difficulty, List<String> recentTitles) {
+        String base = generate(categoryName, difficulty);
+        if (recentTitles == null || recentTitles.isEmpty()) {
+            return base;
+        }
+        String titleList = recentTitles.stream()
+                .map(t -> "- " + t)
+                .collect(Collectors.joining("\n"));
+        return base + "\n\n## 중복 방지 지침\n\n"
+                + "아래는 최근에 이미 출제된 문제 제목입니다. 이와 동일하거나 유사한 주제는 피하고 반드시 다른 개념의 질문을 생성해주세요:\n\n"
+                + titleList + "\n";
     }
 
     /**


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`: #188 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 한 줄 요약
최근 출제된 문제 제목을 AI 프롬프트에 포함하여 중복되는 문제 생성을 방지하고, 백업 문제 선택 로직을 개선함

## 변경 내용

**1. 저장소 쿼리 메서드 개선 (ProblemJpaRepository.java)**
- 기존 `findFirstByCategoryTopicIdAndDifficultyAndStatusOrderByProblemAtDesc` 메서드 제거
- `findLeastRecentlyAssignedProblem` 메서드 추가: DailyProblem의 `assignedAt`이 가장 오래된 문제를 선택하는 JPQL 쿼리 추가 (백업 문제로 사용할 문제를 최근에 할당되지 않은 것으로 우선순위 변경)
- `findRecentTitlesByCategoryTopicIdAndDifficulty` 메서드 추가: 지난 30일 동안 해당 카테고리와 난이도로 출제된 문제의 제목 목록을 반환

**2. 문제 생성 로직 강화 (ProblemGenerator.java)**
- `RECENT_DAYS_LIMIT = 30` 상수 추가
- `generateAndSaveProblem` 메서드: 최근 30일 동안 출제된 문제 제목들을 조회하여 AI 프롬프트에 전달
- 오버로드된 `getProblemToAi(categoryTopicName, difficulty, recentTitles)` 메서드 추가
- `assignBackupProblem` 메서드 개선: 최근 할당되지 않은 문제를 백업으로 선택하고, 백업이 없을 경우 경고 로그 추가

**3. 프롬프트 생성 로직 확장 (Prompt.java)**
- 오버로드된 `generate(categoryName, difficulty, recentTitles)` 메서드 추가
- recentTitles가 제공되면 프롬프트 끝에 "중복 방지 지침" 섹션을 추가하여 AI가 최근 출제된 문제와 유사하지 않은 다른 개념의 질문을 생성하도록 명시적으로 지시

## 영향 범위

- **문제 생성 기능**: 매일 자동으로 실행되는 일일 문제 생성 프로세스 (`generateProblem`)
- **초기 문제 생성**: 신규 회원의 첫 문제 생성 (`generateInitialProblem`)
- **백업 문제 할당**: AI 문제 생성 실패 시 기존 문제를 대체로 사용하는 로직
- **DailyProblem 관리**: 문제 할당 히스토리와 연관된 기능

## 리뷰어 주목 포인트

1. **쿼리 성능**: `findLeastRecentlyAssignedProblem`의 서브쿼리(MAX(dp.assignedAt))가 자주 실행될 경우 성능 영향을 모니터링 필요 (매일 여러 카테고리/난이도별로 실행)

2. **NULL 처리**: `findRecentTitlesByCategoryTopicIdAndDifficulty`에서 반환된 `recentTitles`가 빈 리스트일 때 Prompt.generate에서 null/empty 체크가 되어 있는지 확인 (현재는 적절히 처리됨)

3. **JPQL LIMIT 확장**: Hibernate 6.x의 JPQL LIMIT 문법 사용으로, 다른 JPA 구현체 변경 시 호환성 문제 가능성 있음

4. **백업 문제 없음 시나리오**: 새로운 카테고리의 경우 `findLeastRecentlyAssignedProblem`이 결과를 반환하지 못할 수 있으므로, 이 경우의 처리(경고 로그만 남김)가 의도된 동작인지 확인

5. **30일 제한의 적절성**: `RECENT_DAYS_LIMIT = 30`이 모든 카테고리와 난이도에 적정한 기간인지, 필요시 조정 가능한 설정으로 변경 고려 필요

<!-- end of auto-generated comment: release notes by coderabbit.ai -->