### PR TITLE
Feat: 학습 카테고리 추가 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,7 @@ bad-words.txt
 k6-tests/
 nginx/
 
+docs/트러블슈팅/
 # 모니터링 설정 파일은 포함하되 데이터는 제외
 !monitoring/prometheus/prometheus.yml
 !monitoring/grafana/provisioning/**/*.yml

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.kwakmunsu.haruhana.domain.member.controller.dto.DeviceTokenSyncRequest;
 import org.kwakmunsu.haruhana.domain.member.controller.dto.MemberCreateRequest;
+import org.kwakmunsu.haruhana.domain.member.controller.dto.PreferenceAppendRequest;
 import org.kwakmunsu.haruhana.domain.member.controller.dto.PreferenceUpdateRequest;
 import org.kwakmunsu.haruhana.domain.member.controller.dto.ProfileUpdateRequest;
 import org.kwakmunsu.haruhana.domain.member.service.MemberProfileResponse;
@@ -36,6 +37,19 @@ public class MemberController extends MemberDocsController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(memberId));
+    }
+
+    @Override
+    @PostMapping("/v1/members/preferences")
+    public ResponseEntity<ApiResponse<?>> appendPreference(
+            @RequestBody @Valid PreferenceAppendRequest request,
+            @LoginMember Long memberId
+    ) {
+
+        memberService.appendPreference(request.toNewPreference(), memberId);
+
+        return ResponseEntity.ok(ApiResponse.success());
+
     }
 
     @Override

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberDocsController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberDocsController.java
@@ -15,12 +15,17 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import org.kwakmunsu.haruhana.domain.member.controller.dto.DeviceTokenSyncRequest;
 import org.kwakmunsu.haruhana.domain.member.controller.dto.MemberCreateRequest;
+import org.kwakmunsu.haruhana.domain.member.controller.dto.PreferenceAppendRequest;
 import org.kwakmunsu.haruhana.domain.member.controller.dto.PreferenceUpdateRequest;
 import org.kwakmunsu.haruhana.domain.member.controller.dto.ProfileUpdateRequest;
 import org.kwakmunsu.haruhana.domain.member.service.MemberProfileResponse;
+import org.kwakmunsu.haruhana.global.annotation.LoginMember;
 import org.kwakmunsu.haruhana.global.support.response.ApiResponse;
 import org.kwakmunsu.haruhana.global.swagger.ApiExceptions;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Member Docs", description = "Member 관련 API 문서")
 public abstract class MemberDocsController {
@@ -59,6 +64,21 @@ public abstract class MemberDocsController {
     public abstract ResponseEntity<ApiResponse<?>> updatePreference(
             @Valid PreferenceUpdateRequest request,
             Long memberId
+    );
+
+    @Operation(
+            summary = "회원 학습 정보 추가 - JWT [O]",
+            description = """
+                    ### 회원의 학습 정보를 추가합니다.
+                    - 카테고리 주제 ID와 난이도를 포함한 요청을 받습니다.
+                    - 성공 시 빈 응답을 반환합니다.
+                    - 추가된 학습 정보는 당일부터 적용되고 문제는 바로 출제됩니다.
+                    - 최대 5개의 학습 정보까지 추가할 수 있습니다.
+                    """
+    )
+    public abstract ResponseEntity<ApiResponse<?>> appendPreference(
+            @RequestBody @Valid PreferenceAppendRequest request,
+            @LoginMember Long memberId
     );
 
     @Operation(

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberDocsController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberDocsController.java
@@ -7,6 +7,7 @@ import static org.kwakmunsu.haruhana.global.support.error.ErrorType.DUPLICATE_NI
 import static org.kwakmunsu.haruhana.global.support.error.ErrorType.NOT_FOUND_CATEGORY;
 import static org.kwakmunsu.haruhana.global.support.error.ErrorType.NOT_FOUND_FCM_TOKEN;
 import static org.kwakmunsu.haruhana.global.support.error.ErrorType.NOT_FOUND_MEMBER;
+import static org.kwakmunsu.haruhana.global.support.error.ErrorType.NOT_FOUND_MEMBER_PREFERENCE;
 import static org.kwakmunsu.haruhana.global.support.error.ErrorType.UNAUTHORIZED_ERROR;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -76,6 +77,12 @@ public abstract class MemberDocsController {
                     - 최대 5개의 학습 정보까지 추가할 수 있습니다.
                     """
     )
+    @ApiExceptions(values = {
+            BAD_REQUEST,
+            NOT_FOUND_MEMBER,
+            NOT_FOUND_MEMBER_PREFERENCE,
+            DEFAULT_ERROR
+    })
     public abstract ResponseEntity<ApiResponse<?>> appendPreference(
             @RequestBody @Valid PreferenceAppendRequest request,
             @LoginMember Long memberId

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/dto/PreferenceAppendRequest.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/dto/PreferenceAppendRequest.java
@@ -7,8 +7,8 @@ import org.kwakmunsu.haruhana.domain.problem.enums.ProblemDifficulty;
 
 @Schema(description = "회원 학습 설정 추가 요청 DTO")
 public record PreferenceAppendRequest(
-        @Schema(description = "카테고리 ID", example = "1")
-        @NotNull(message = "카테고리는 필수입니다.")
+        @Schema(description = "카테고리 주제 ID", example = "1")
+        @NotNull(message = "카테고리 주제는 필수입니다.")
         Long categoryTopicId,
 
         @Schema(description = "문제 난이도", example = "EASY")

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/dto/PreferenceAppendRequest.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/dto/PreferenceAppendRequest.java
@@ -1,0 +1,26 @@
+package org.kwakmunsu.haruhana.domain.member.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.kwakmunsu.haruhana.domain.member.service.dto.request.NewPreference;
+import org.kwakmunsu.haruhana.domain.problem.enums.ProblemDifficulty;
+
+@Schema(description = "회원 학습 설정 추가 요청 DTO")
+public record PreferenceAppendRequest(
+        @Schema(description = "카테고리 ID", example = "1")
+        @NotNull(message = "카테고리는 필수입니다.")
+        Long categoryTopicId,
+
+        @Schema(description = "문제 난이도", example = "EASY")
+        @NotNull(message = "난이도는 필수입니다.")
+        ProblemDifficulty difficulty
+) {
+
+    public NewPreference toNewPreference() {
+        return NewPreference.builder()
+                .categoryTopicId(categoryTopicId)
+                .difficulty(difficulty)
+                .build();
+    }
+
+}

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/entity/MemberPreference.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/entity/MemberPreference.java
@@ -61,7 +61,7 @@ public class MemberPreference extends BaseEntity {
         return (this.categoryTopic.getId().equals(categoryTopicId) && this.difficulty == difficulty);
     }
 
-    public boolean isEffectiveToday() {
+    public boolean isScheduledForTomorrow() {
         return this.effectiveAt.isEqual(LocalDate.now().plusDays(1));
     }
 

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/repository/MemberJpaRepository.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/repository/MemberJpaRepository.java
@@ -7,8 +7,11 @@ import org.kwakmunsu.haruhana.domain.member.entity.Member;
 import org.kwakmunsu.haruhana.domain.member.enums.Role;
 import org.kwakmunsu.haruhana.global.entity.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.LockModeType;
 
 public interface MemberJpaRepository extends JpaRepository<Member, Long> {
 
@@ -16,6 +19,10 @@ public interface MemberJpaRepository extends JpaRepository<Member, Long> {
     boolean existsByNicknameAndStatus(String nickname, EntityStatus status);
     Optional<Member> findByLoginIdAndStatus(String loginId, EntityStatus status);
     Optional<Member> findByIdAndStatus(Long id, EntityStatus entityStatus);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT m FROM Member m WHERE m.id = :id AND m.status = :status")
+    Optional<Member> findByIdAndStatusWithLock(@Param("id") Long id, @Param("status") EntityStatus status);
     Optional<Member> findByRefreshTokenAndStatus(String refreshToken, EntityStatus status);
 
     @Query("""

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/repository/MemberPreferenceJpaRepository.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/repository/MemberPreferenceJpaRepository.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.kwakmunsu.haruhana.domain.member.entity.MemberPreference;
+import org.kwakmunsu.haruhana.domain.problem.enums.ProblemDifficulty;
 import org.kwakmunsu.haruhana.global.entity.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -25,4 +26,7 @@ public interface MemberPreferenceJpaRepository extends JpaRepository<MemberPrefe
     @Query("UPDATE MemberPreference mp SET mp.status = :status, mp.updatedAt = :now WHERE mp.member.id = :memberId AND mp.status = 'ACTIVE'")
     void softDeleteByMemberId(@Param("memberId") Long memberId, @Param("status") EntityStatus status, @Param("now") LocalDateTime now);
 
+    int countByMemberIdAndStatus(Long memberId, EntityStatus status);
+
+    boolean existsByMemberIdAndCategoryTopicIdAndDifficultyAndStatus(Long memberId, Long aLong, ProblemDifficulty difficulty, EntityStatus entityStatus);
 }

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberManager.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberManager.java
@@ -13,6 +13,9 @@ import org.kwakmunsu.haruhana.domain.member.repository.MemberPreferenceJpaReposi
 import org.kwakmunsu.haruhana.domain.member.service.dto.request.NewPreference;
 import org.kwakmunsu.haruhana.domain.member.service.dto.request.NewProfile;
 import org.kwakmunsu.haruhana.domain.member.service.dto.request.UpdatePreference;
+import org.kwakmunsu.haruhana.global.entity.EntityStatus;
+import org.kwakmunsu.haruhana.global.support.error.ErrorType;
+import org.kwakmunsu.haruhana.global.support.error.HaruHanaException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,6 +42,7 @@ public class MemberManager {
         return member;
     }
 
+    @Transactional
     public MemberPreference registerPreference(Member member, NewPreference newPreference) {
         CategoryTopic categoryTopic = categoryReader.findCategoryTopic(newPreference.categoryTopicId());
 
@@ -58,11 +62,11 @@ public class MemberManager {
         Member member = memberPreference.getMember();
         CategoryTopic categoryTopic = categoryReader.findCategoryTopic(updatePreference.categoryTopicId());
 
-        // 같은 날짜에 회원 설정 변경 시 기존 설정을 업데이트하는 방식으로 처리
-        if (memberPreference.isEffectiveToday()) {
+        // 이미 내일 날짜로 예약된 설정이 있으면 인플레이스 수정, 아니면 소프트 삭제 후 내일 날짜로 재생성
+        if (memberPreference.isScheduledForTomorrow()) {
             memberPreference.updatePreference(categoryTopic, updatePreference.difficulty());
         } else {
-            // 다음 날부터 적용되는 설정 변경 시 기존 설정을 삭제하고 새로운 설정을 생성하는 방식으로 처리
+            // 오늘 기준 설정 변경 시 기존 설정을 삭제하고 내일부터 적용되는 새로운 설정을 생성
             preferenceUpdateForTomorrow(memberPreference, member, categoryTopic, updatePreference);
         }
 
@@ -77,6 +81,7 @@ public class MemberManager {
     public void clearMember(Member member) {
         member.clearRefreshToken();
     }
+
 
     private void preferenceUpdateForTomorrow(
             MemberPreference memberPreference,
@@ -94,5 +99,4 @@ public class MemberManager {
                 LocalDate.now().plusDays(1)
         ));
     }
-
 }

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberReader.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberReader.java
@@ -38,6 +38,11 @@ public class MemberReader {
                 .orElseThrow(() -> new HaruHanaException(ErrorType.NOT_FOUND_MEMBER));
     }
 
+    public Member findWithLock(Long id) {
+        return memberJpaRepository.findByIdAndStatusWithLock(id, EntityStatus.ACTIVE)
+                .orElseThrow(() -> new HaruHanaException(ErrorType.NOT_FOUND_MEMBER));
+    }
+
     public long countAll() {
         return memberJpaRepository.countAllByStatus(EntityStatus.ACTIVE);
     }
@@ -76,4 +81,5 @@ public class MemberReader {
     public boolean existsByLoginId(String loginId) {
         return memberJpaRepository.existsByLoginIdAndStatus(loginId, EntityStatus.ACTIVE);
     }
+
 }

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberService.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberService.java
@@ -46,11 +46,8 @@ public class MemberService {
         memberValidator.validateNew(newProfile);
 
         Member member = memberManager.create(newProfile);
-
         MemberPreference memberPreference = memberManager.registerPreference(member, newPreference);
-
         streakManager.create(member);
-
         // 회원가입 시에만 오늘의 문제 문제 직접 생성 - Async 처리
         problemGenerator.generateInitialProblem(member, memberPreference.getCategoryTopic(), memberPreference.getDifficulty());
 
@@ -90,6 +87,26 @@ public class MemberService {
 
         log.info("[MemberService] 프로필 업데이트 완료 - memberId: {}, hasProfileImage: {}",
                 memberId, updateProfile.profileImageKey() != null);
+    }
+
+    /**
+     * 회원 선호 학습 정보 추가 등록 <br>
+     * 최대 등록 가능한 선호 학습 정보 개수와 중복 카테고리 존재 여부를 함께 검증합니다. <br>
+     * 추가된 선호 학습 정보는 당일부터 적용됩니다. <br>
+     * 추가된 선호 학습 정보에 해당하는 오늘의 문제를 직접 생성합니다. (Async 처리) <br>
+     * @param newPreference 추가할 선호 학습 정보
+     * @param memberId 회원 식별자
+     * */
+    @Transactional
+    public void appendPreference(NewPreference newPreference, Long memberId) {
+        Member member = memberReader.findWithLock(memberId);
+        memberValidator.validateAppendPreference(newPreference, memberId);
+        MemberPreference memberPreference = memberManager.registerPreference(member, newPreference);
+
+        problemGenerator.generateInitialProblem(member, memberPreference.getCategoryTopic(), memberPreference.getDifficulty());
+
+        log.info("[MemberService] 학습 선호도 추가 완료 - memberId: {}, categoryTopicId: {}, difficulty: {}",
+                memberId, newPreference.categoryTopicId(), newPreference.difficulty());
     }
 
     /**

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberValidator.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberValidator.java
@@ -3,6 +3,8 @@ package org.kwakmunsu.haruhana.domain.member.service;
 import lombok.RequiredArgsConstructor;
 import org.kwakmunsu.haruhana.domain.member.entity.Member;
 import org.kwakmunsu.haruhana.domain.member.repository.MemberJpaRepository;
+import org.kwakmunsu.haruhana.domain.member.repository.MemberPreferenceJpaRepository;
+import org.kwakmunsu.haruhana.domain.member.service.dto.request.NewPreference;
 import org.kwakmunsu.haruhana.domain.member.service.dto.request.NewProfile;
 import org.kwakmunsu.haruhana.domain.member.service.dto.request.UpdateProfile;
 import org.kwakmunsu.haruhana.global.entity.EntityStatus;
@@ -14,7 +16,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class MemberValidator {
 
+    private static final int MAX_PREFERENCE_COUNT = 5;
+
     private final MemberJpaRepository memberJpaRepository;
+    private final MemberPreferenceJpaRepository memberPreferenceJpaRepository;
     private final NicknameFilter nicknameFilter;
 
     public void validateNew(NewProfile newProfile) {
@@ -36,13 +41,6 @@ public class MemberValidator {
         }
     }
 
-    private void validateNicknameAvailable(String nickname) {
-        nicknameFilter.validate(nickname);
-        if (memberJpaRepository.existsByNicknameAndStatus(nickname, EntityStatus.ACTIVE)) {
-            throw new HaruHanaException(ErrorType.DUPLICATE_NICKNAME);
-        }
-    }
-
     public boolean isNicknameAvailable(String nickname) {
         try {
             nicknameFilter.validate(nickname);
@@ -55,4 +53,31 @@ public class MemberValidator {
         return true;
     }
 
+    /**
+     * 회원 선호 학습 정보 등록 시, 최대 등록 가능한 선호 학습 정보 개수와 중복 카테고리 존재 여부를 검증한다.
+     *
+     */
+    public void validateAppendPreference(NewPreference newPreference, Long memberId) {
+        int currentPreferenceCount = memberPreferenceJpaRepository.countByMemberIdAndStatus(memberId, EntityStatus.ACTIVE);
+        if (currentPreferenceCount >= MAX_PREFERENCE_COUNT) {
+            throw new HaruHanaException(ErrorType.EXCEED_MAX_PREFERENCE_COUNT);
+        }
+
+        boolean isExistingPreference = memberPreferenceJpaRepository.existsByMemberIdAndCategoryTopicIdAndDifficultyAndStatus(
+                memberId,
+                newPreference.categoryTopicId(),
+                newPreference.difficulty(),
+                EntityStatus.ACTIVE
+        );
+        if (isExistingPreference) {
+            throw new HaruHanaException(ErrorType.DUPLICATE_PREFERENCE);
+        }
+    }
+
+    private void validateNicknameAvailable(String nickname) {
+        nicknameFilter.validate(nickname);
+        if (memberJpaRepository.existsByNicknameAndStatus(nickname, EntityStatus.ACTIVE)) {
+            throw new HaruHanaException(ErrorType.DUPLICATE_NICKNAME);
+        }
+    }
 }

--- a/src/main/java/org/kwakmunsu/haruhana/global/support/error/ErrorType.java
+++ b/src/main/java/org/kwakmunsu/haruhana/global/support/error/ErrorType.java
@@ -23,11 +23,13 @@ public enum ErrorType {
     // MEMBER
     INVALID_ACCOUNT                          (HttpStatus.UNAUTHORIZED, "계정 정보가 일치하지 않습니다.", LogLevel.WARN),
     INVALID_NICKNAME                         (HttpStatus.BAD_REQUEST, "사용할 수 없는 닉네임입니다.", LogLevel.INFO),
+    EXCEED_MAX_PREFERENCE_COUNT              (HttpStatus.BAD_REQUEST, "회원 학습 정보는 최대 5개까지 등록 가능합니다.", LogLevel.INFO),
     NOT_FOUND_MEMBER                         (HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다.", LogLevel.INFO),
     NOT_FOUND_ACTIVE_MEMBER_BY_REFRESH_TOKEN (HttpStatus.NOT_FOUND, "요청하신 Refresh Token 으로 활성화 된 회원을 찾을 수 없습니다.", LogLevel.INFO),
+    NOT_FOUND_MEMBER_PREFERENCE              (HttpStatus.NOT_FOUND, "회원 학습 정보를 찾을 수 없습니다.", LogLevel.ERROR), // 회원 정보는 없으면 안되기에 Error
     DUPLICATE_LOGIN_ID                       (HttpStatus.CONFLICT, "이미 사용 중인 로그인 아이디입니다.", LogLevel.INFO),
     DUPLICATE_NICKNAME                       (HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.", LogLevel.INFO),
-    NOT_FOUND_MEMBER_PREFERENCE(HttpStatus.NOT_FOUND, "회원 선호 정보를 찾을 수 없습니다.", LogLevel.ERROR), // 회원 정보는 없으면 안되기에 Error
+    DUPLICATE_PREFERENCE                     (HttpStatus.CONFLICT, "이미 등록된 학습정보 입니다.", LogLevel.INFO),
 
     // MEMBER DEVICE
     NOT_FOUND_MEMBER_DEVICE (HttpStatus.NOT_FOUND, "회원 디바이스 정보를 찾을 수 없습니다.", LogLevel.INFO),

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/controller/MemberControllerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.kwakmunsu.haruhana.ControllerTestSupport;
 import org.kwakmunsu.haruhana.domain.member.MemberFixture;
 import org.kwakmunsu.haruhana.domain.member.controller.dto.DeviceTokenSyncRequest;
+import org.kwakmunsu.haruhana.domain.member.controller.dto.PreferenceAppendRequest;
 import org.kwakmunsu.haruhana.domain.member.controller.dto.PreferenceUpdateRequest;
 import org.kwakmunsu.haruhana.domain.member.controller.dto.ProfileUpdateRequest;
 import org.kwakmunsu.haruhana.domain.member.enums.Role;
@@ -165,6 +166,53 @@ class MemberControllerTest extends ControllerTestSupport {
 
         // then
         verify(memberService, times(1)).checkLoginIdAvailable("사용가능한LoginId");
+    }
+
+    @TestMember
+    @Test
+    void 회원_학습_선호_정보_추가_Api를_요청한다() throws JsonProcessingException {
+        // given
+        var request = new PreferenceAppendRequest(1L, ProblemDifficulty.MEDIUM);
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        // when & then
+        assertThat(mvcTester.post().uri("/v1/members/preferences")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson))
+                .apply(print())
+                .hasStatus(HttpStatus.CREATED);
+
+        verify(memberService, times(1)).appendPreference(any(), any());
+    }
+
+    @TestMember
+    @Test
+    void categoryTopicId가_null이면_400_에러를_반환한다() throws JsonProcessingException {
+        // given
+        var request = new PreferenceAppendRequest(null, ProblemDifficulty.MEDIUM);
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        // when & then
+        assertThat(mvcTester.post().uri("/v1/members/preferences")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson))
+                .apply(print())
+                .hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @TestMember
+    @Test
+    void difficulty가_null이면_400_에러를_반환한다() throws JsonProcessingException {
+        // given
+        var request = new PreferenceAppendRequest(1L, null);
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        // when & then
+        assertThat(mvcTester.post().uri("/v1/members/preferences")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson))
+                .apply(print())
+                .hasStatus(HttpStatus.BAD_REQUEST);
     }
 
 }

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/entity/MemberPreferenceTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/entity/MemberPreferenceTest.java
@@ -1,0 +1,56 @@
+package org.kwakmunsu.haruhana.domain.member.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.kwakmunsu.haruhana.domain.category.entity.CategoryTopic;
+import org.kwakmunsu.haruhana.domain.member.MemberFixture;
+import org.kwakmunsu.haruhana.domain.member.enums.Role;
+import org.kwakmunsu.haruhana.domain.problem.enums.ProblemDifficulty;
+
+class MemberPreferenceTest {
+
+    @Test
+    void effectiveAt이_내일_날짜이면_true를_반환한다() {
+        // given
+        var member = MemberFixture.createMember(Role.ROLE_MEMBER);
+        var categoryTopic = CategoryTopic.create(1L, "알고리즘");
+        var memberPreference = MemberPreference.create(member, categoryTopic, ProblemDifficulty.MEDIUM, LocalDate.now().plusDays(1));
+
+        // when
+        var result = memberPreference.isScheduledForTomorrow();
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void effectiveAt이_오늘_날짜이면_false를_반환한다() {
+        // given
+        var member = MemberFixture.createMember(Role.ROLE_MEMBER);
+        var categoryTopic = CategoryTopic.create(1L, "알고리즘");
+        var memberPreference = MemberPreference.create(member, categoryTopic, ProblemDifficulty.MEDIUM, LocalDate.now());
+
+        // when
+        var result = memberPreference.isScheduledForTomorrow();
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void effectiveAt이_과거_날짜이면_false를_반환한다() {
+        // given
+        var member = MemberFixture.createMember(Role.ROLE_MEMBER);
+        var categoryTopic = CategoryTopic.create(1L, "알고리즘");
+        var memberPreference = MemberPreference.create(member, categoryTopic, ProblemDifficulty.MEDIUM, LocalDate.now().minusDays(1));
+
+        // when
+        var result = memberPreference.isScheduledForTomorrow();
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+}

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberPreferenceAppendConcurrencyTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberPreferenceAppendConcurrencyTest.java
@@ -1,0 +1,141 @@
+package org.kwakmunsu.haruhana.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kwakmunsu.haruhana.IntegrationTestSupport;
+import org.kwakmunsu.haruhana.domain.category.CategoryFactory;
+import org.kwakmunsu.haruhana.domain.category.repository.CategoryTopicJpaRepository;
+import org.kwakmunsu.haruhana.domain.member.MemberFixture;
+import org.kwakmunsu.haruhana.domain.member.repository.MemberJpaRepository;
+import org.kwakmunsu.haruhana.domain.member.repository.MemberPreferenceJpaRepository;
+import org.kwakmunsu.haruhana.domain.member.service.dto.request.NewPreference;
+import org.kwakmunsu.haruhana.domain.problem.enums.ProblemDifficulty;
+import org.kwakmunsu.haruhana.domain.problem.service.ProblemGenerator;
+import org.kwakmunsu.haruhana.domain.streak.service.StreakManager;
+import org.kwakmunsu.haruhana.global.entity.EntityStatus;
+import org.kwakmunsu.haruhana.global.support.error.HaruHanaException;
+import org.kwakmunsu.haruhana.global.support.image.StorageProvider;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@RequiredArgsConstructor
+class MemberPreferenceAppendConcurrencyTest extends IntegrationTestSupport {
+
+    final CategoryFactory categoryFactory;
+    final MemberService memberService;
+    final MemberJpaRepository memberJpaRepository;
+    final MemberPreferenceJpaRepository memberPreferenceJpaRepository;
+    final CategoryTopicJpaRepository categoryTopicJpaRepository;
+
+    @MockitoBean
+    ProblemGenerator problemGenerator;
+
+    @MockitoBean
+    StreakManager streakManager;
+
+    @MockitoBean
+    StorageProvider storageProvider;
+
+    @BeforeEach
+    void setUp() {
+        categoryFactory.deleteAll();
+        categoryFactory.saveAll();
+
+        doNothing().when(problemGenerator).generateInitialProblem(any(), any(), any());
+        doNothing().when(streakManager).create(any());
+    }
+
+    @AfterEach
+    void tearDown() {
+        memberPreferenceJpaRepository.deleteAll();
+        memberJpaRepository.deleteAll();
+        categoryFactory.deleteAll();
+    }
+
+    @Test
+    void 동시에_5개_선호_정보_추가_요청_시_최대_개수를_초과하지_않는다() throws InterruptedException {
+        // given
+        var loginId = UUID.randomUUID().toString().substring(0, 20);
+        var nickname = UUID.randomUUID().toString().substring(0, 20);
+        var member = MemberFixture.createMemberWithOutId(loginId, nickname);
+        memberJpaRepository.save(member);
+
+        var javaTopic = categoryTopicJpaRepository.findByName("Java")
+                .orElseThrow(() -> new RuntimeException("Java 토픽이 존재하지 않습니다"));
+        var pythonTopic = categoryTopicJpaRepository.findByName("Python")
+                .orElseThrow(() -> new RuntimeException("Python 토픽이 존재하지 않습니다"));
+        var cppTopic = categoryTopicJpaRepository.findByName("C/C++")
+                .orElseThrow(() -> new RuntimeException("C/C++ 토픽이 존재하지 않습니다"));
+        var jsTopic = categoryTopicJpaRepository.findByName("JavaScript")
+                .orElseThrow(() -> new RuntimeException("JavaScript 토픽이 존재하지 않습니다"));
+
+        memberService.appendPreference(new NewPreference(javaTopic.getId(), ProblemDifficulty.MEDIUM), member.getId());
+        memberService.appendPreference(new NewPreference(pythonTopic.getId(), ProblemDifficulty.MEDIUM), member.getId());
+        memberService.appendPreference(new NewPreference(cppTopic.getId(), ProblemDifficulty.MEDIUM), member.getId());
+        memberService.appendPreference(new NewPreference(jsTopic.getId(), ProblemDifficulty.MEDIUM), member.getId());
+
+        var goTopic = categoryTopicJpaRepository.findByName("Go")
+                .orElseThrow(() -> new RuntimeException("Go 토픽이 존재하지 않습니다"));
+        var kotlinTopic = categoryTopicJpaRepository.findByName("Kotlin")
+                .orElseThrow(() -> new RuntimeException("Kotlin 토픽이 존재하지 않습니다"));
+        var swiftTopic = categoryTopicJpaRepository.findByName("Swift")
+                .orElseThrow(() -> new RuntimeException("Swift 토픽이 존재하지 않습니다"));
+        var rubyTopic = categoryTopicJpaRepository.findByName("Ruby")
+                .orElseThrow(() -> new RuntimeException("Ruby 토픽이 존재하지 않습니다"));
+        var springTopic = categoryTopicJpaRepository.findByName("Spring")
+                .orElseThrow(() -> new RuntimeException("Spring 토픽이 존재하지 않습니다"));
+
+        var concurrentTopicIds = new Long[]{
+                goTopic.getId(),
+                kotlinTopic.getId(),
+                swiftTopic.getId(),
+                rubyTopic.getId(),
+                springTopic.getId()
+        };
+
+        int threadCount = 5;
+        var executorService = Executors.newFixedThreadPool(threadCount);
+        var latch = new CountDownLatch(threadCount);
+        var successCount = new AtomicInteger(0);
+        var failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            int index = i;
+            executorService.submit(() -> {
+                try {
+                    latch.countDown();
+                    latch.await();
+                    memberService.appendPreference(
+                            new NewPreference(concurrentTopicIds[index], ProblemDifficulty.MEDIUM),
+                            member.getId()
+                    );
+                    successCount.incrementAndGet();
+                } catch (HaruHanaException e) {
+                    failCount.incrementAndGet();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        executorService.shutdown();
+        executorService.awaitTermination(10, java.util.concurrent.TimeUnit.SECONDS);
+
+        // then
+        var finalCount = memberPreferenceJpaRepository.countByMemberIdAndStatus(member.getId(), EntityStatus.ACTIVE);
+        assertThat(finalCount).isEqualTo(5);
+        assertThat(successCount.get()).isEqualTo(1);
+    }
+
+}

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberServiceIntegrationTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberServiceIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.kwakmunsu.haruhana.domain.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -22,6 +23,8 @@ import org.kwakmunsu.haruhana.domain.member.repository.MemberJpaRepository;
 import org.kwakmunsu.haruhana.domain.member.repository.MemberPreferenceJpaRepository;
 import org.kwakmunsu.haruhana.domain.member.service.dto.request.NewPreference;
 import org.kwakmunsu.haruhana.domain.member.service.dto.request.UpdateProfile;
+import org.kwakmunsu.haruhana.global.support.error.ErrorType;
+import org.kwakmunsu.haruhana.global.support.error.HaruHanaException;
 import org.kwakmunsu.haruhana.domain.problem.enums.ProblemDifficulty;
 import org.kwakmunsu.haruhana.domain.problem.service.ProblemGenerator;
 import org.kwakmunsu.haruhana.domain.storage.enums.UploadType;
@@ -223,6 +226,70 @@ class MemberServiceIntegrationTest extends IntegrationTestSupport {
         ).orElseThrow();
 
         assertThat(storage.isComplete()).isTrue();
+    }
+
+    @Test
+    void 학습_선호_정보를_추가한다() {
+        // given
+        var newProfile = MemberFixture.createNewProfile();
+        var newPreference = new NewPreference(categoryTopic.getId(), ProblemDifficulty.EASY);
+        Long memberId = memberService.createMember(newProfile, newPreference);
+
+        var springTopic = categoryTopicJpaRepository.findByName("Spring")
+                .orElseThrow(() -> new RuntimeException("Spring 토픽이 존재하지 않습니다"));
+        var appendPreference = new NewPreference(springTopic.getId(), ProblemDifficulty.MEDIUM);
+
+        // when
+        memberService.appendPreference(appendPreference, memberId);
+
+        // then
+        var count = memberPreferenceJpaRepository.countByMemberIdAndStatus(memberId, org.kwakmunsu.haruhana.global.entity.EntityStatus.ACTIVE);
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    void 최대_개수_초과_시_예외가_발생한다() {
+        // given
+        var newProfile = MemberFixture.createNewProfile();
+        var newPreference = new NewPreference(categoryTopic.getId(), ProblemDifficulty.EASY);
+        Long memberId = memberService.createMember(newProfile, newPreference);
+
+        var springTopic = categoryTopicJpaRepository.findByName("Spring")
+                .orElseThrow(() -> new RuntimeException("Spring 토픽이 존재하지 않습니다"));
+        var mysqlTopic = categoryTopicJpaRepository.findByName("MySQL")
+                .orElseThrow(() -> new RuntimeException("MySQL 토픽이 존재하지 않습니다"));
+        var pythonTopic = categoryTopicJpaRepository.findByName("Python")
+                .orElseThrow(() -> new RuntimeException("Python 토픽이 존재하지 않습니다"));
+        var goTopic = categoryTopicJpaRepository.findByName("Go")
+                .orElseThrow(() -> new RuntimeException("Go 토픽이 존재하지 않습니다"));
+        var kotlinTopic = categoryTopicJpaRepository.findByName("Kotlin")
+                .orElseThrow(() -> new RuntimeException("Kotlin 토픽이 존재하지 않습니다"));
+
+        memberService.appendPreference(new NewPreference(springTopic.getId(), ProblemDifficulty.MEDIUM), memberId);
+        memberService.appendPreference(new NewPreference(mysqlTopic.getId(), ProblemDifficulty.MEDIUM), memberId);
+        memberService.appendPreference(new NewPreference(pythonTopic.getId(), ProblemDifficulty.MEDIUM), memberId);
+        memberService.appendPreference(new NewPreference(goTopic.getId(), ProblemDifficulty.MEDIUM), memberId);
+
+        // when & then
+        var sixthPreference = new NewPreference(kotlinTopic.getId(), ProblemDifficulty.MEDIUM);
+        assertThatThrownBy(() -> memberService.appendPreference(sixthPreference, memberId))
+                .isInstanceOf(HaruHanaException.class)
+                .hasMessage(ErrorType.EXCEED_MAX_PREFERENCE_COUNT.getMessage());
+    }
+
+    @Test
+    void 중복_선호_정보_추가_시_예외가_발생한다() {
+        // given
+        var newProfile = MemberFixture.createNewProfile();
+        var newPreference = new NewPreference(categoryTopic.getId(), ProblemDifficulty.EASY);
+        Long memberId = memberService.createMember(newProfile, newPreference);
+
+        var duplicatePreference = new NewPreference(categoryTopic.getId(), ProblemDifficulty.EASY);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.appendPreference(duplicatePreference, memberId))
+                .isInstanceOf(HaruHanaException.class)
+                .hasMessage(ErrorType.DUPLICATE_PREFERENCE.getMessage());
     }
 
     @Test

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberServiceUnitTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberServiceUnitTest.java
@@ -15,8 +15,10 @@ import org.kwakmunsu.haruhana.domain.category.entity.CategoryTopic;
 import org.kwakmunsu.haruhana.domain.member.MemberFixture;
 import org.kwakmunsu.haruhana.domain.member.entity.MemberPreference;
 import org.kwakmunsu.haruhana.domain.member.enums.Role;
+import org.kwakmunsu.haruhana.domain.member.service.dto.request.NewPreference;
 import org.kwakmunsu.haruhana.domain.member.service.dto.request.UpdatePreference;
 import org.kwakmunsu.haruhana.domain.problem.enums.ProblemDifficulty;
+import org.kwakmunsu.haruhana.domain.problem.service.ProblemGenerator;
 import org.kwakmunsu.haruhana.global.support.image.StorageProvider;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -30,7 +32,13 @@ class MemberServiceUnitTest extends UnitTestSupport {
     MemberManager memberManager;
 
     @Mock
+    MemberValidator memberValidator;
+
+    @Mock
     MemberRemover memberRemover;
+
+    @Mock
+    ProblemGenerator problemGenerator;
 
     @Mock
     StorageProvider storageProvider;
@@ -138,6 +146,27 @@ class MemberServiceUnitTest extends UnitTestSupport {
 
         // then
         assertThat(idAvailable).isFalse();
+    }
+
+    @Test
+    void 회원_학습_선호_정보를_추가한다() {
+        // given
+        var member = MemberFixture.createMember(Role.ROLE_MEMBER);
+        var categoryTopic = CategoryTopic.create(1L, "Java");
+        var memberPreference = MemberPreference.create(member, categoryTopic, ProblemDifficulty.MEDIUM, LocalDate.now());
+        var newPreference = new NewPreference(1L, ProblemDifficulty.MEDIUM);
+
+        given(memberReader.findWithLock(member.getId())).willReturn(member);
+        given(memberManager.registerPreference(member, newPreference)).willReturn(memberPreference);
+
+        // when
+        memberService.appendPreference(newPreference, member.getId());
+
+        // then
+        verify(memberReader, times(1)).findWithLock(member.getId());
+        verify(memberValidator, times(1)).validateAppendPreference(newPreference, member.getId());
+        verify(memberManager, times(1)).registerPreference(member, newPreference);
+        verify(problemGenerator, times(1)).generateInitialProblem(any(), any(), any());
     }
 
 }

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberValidatorUnitTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberValidatorUnitTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 import org.kwakmunsu.haruhana.UnitTestSupport;
 import org.kwakmunsu.haruhana.domain.member.MemberFixture;
 import org.kwakmunsu.haruhana.domain.member.repository.MemberJpaRepository;
+import org.kwakmunsu.haruhana.domain.member.repository.MemberPreferenceJpaRepository;
+import org.kwakmunsu.haruhana.global.entity.EntityStatus;
 import org.kwakmunsu.haruhana.global.support.error.ErrorType;
 import org.kwakmunsu.haruhana.global.support.error.HaruHanaException;
 import org.mockito.InjectMocks;
@@ -21,6 +23,9 @@ class MemberValidatorUnitTest extends UnitTestSupport {
 
     @Mock
     MemberJpaRepository memberJpaRepository;
+
+    @Mock
+    MemberPreferenceJpaRepository memberPreferenceJpaRepository;
 
     @Mock
     NicknameFilter nicknameFilter;
@@ -116,6 +121,45 @@ class MemberValidatorUnitTest extends UnitTestSupport {
 
         // then
         assertThat(nicknameAvailable).isFalse();
+    }
+
+    @Test
+    void 선호_정보_추가_검증이_정상적으로_통과한다() {
+        // given
+        given(memberPreferenceJpaRepository.countByMemberIdAndStatus(any(), any())).willReturn(3);
+        given(memberPreferenceJpaRepository.existsByMemberIdAndCategoryTopicIdAndDifficultyAndStatus(any(), any(), any(), any())).willReturn(false);
+
+        var newPreference = MemberFixture.createNewPreference(1L);
+
+        // when & then
+        memberValidator.validateAppendPreference(newPreference, 1L);
+    }
+
+    @Test
+    void 선호_정보_최대_개수_초과_시_예외가_발생한다() {
+        // given
+        given(memberPreferenceJpaRepository.countByMemberIdAndStatus(any(), any())).willReturn(5);
+
+        var newPreference = MemberFixture.createNewPreference(1L);
+
+        // when & then
+        assertThatThrownBy(() -> memberValidator.validateAppendPreference(newPreference, 1L))
+                .isInstanceOf(HaruHanaException.class)
+                .hasMessage(ErrorType.EXCEED_MAX_PREFERENCE_COUNT.getMessage());
+    }
+
+    @Test
+    void 이미_등록된_선호_정보_추가_시_예외가_발생한다() {
+        // given
+        given(memberPreferenceJpaRepository.countByMemberIdAndStatus(any(), any())).willReturn(3);
+        given(memberPreferenceJpaRepository.existsByMemberIdAndCategoryTopicIdAndDifficultyAndStatus(any(), any(), any(), any())).willReturn(true);
+
+        var newPreference = MemberFixture.createNewPreference(1L);
+
+        // when & then
+        assertThatThrownBy(() -> memberValidator.validateAppendPreference(newPreference, 1L))
+                .isInstanceOf(HaruHanaException.class)
+                .hasMessage(ErrorType.DUPLICATE_PREFERENCE.getMessage());
     }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`:  #192 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 한 줄 요약
회원이 학습 카테고리를 추가할 수 있는 API 엔드포인트를 구현하고 동시성 제어를 통해 최대 5개 카테고리 제한과 중복 방지 로직을 적용함

## 변경 내용

### API 엔드포인트 추가
- **POST /v1/members/preferences 엔드포인트** (`MemberController.appendPreference`)
  - `PreferenceAppendRequest` (categoryTopicId, difficulty)를 받아 회원의 학습 카테고리 추가
  - 인증된 회원만 요청 가능 (`@LoginMember` 사용)
  - 새 선호도 등록 후 초기 문제 자동 생성

### 데이터베이스 레이어
- **MemberJpaRepository**: `findByIdAndStatusWithLock()` 메서드 추가
  - `PESSIMISTIC_WRITE` 락을 적용하여 동시 접근 제어
- **MemberPreferenceJpaRepository**: 쿼리 메서드 추가
  - `countByMemberIdAndStatus()`: 회원의 활성 선호도 개수 조회
  - `existsByMemberIdAndCategoryTopicIdAndDifficultyAndStatus()`: 중복 선호도 확인

### 비즈니스 로직 레이어
- **MemberService.appendPreference()**
  - 회원을 락으로 조회하고 검증 후 선호도 등록
  - 등록된 선호도의 카테고리/난이도로 초기 문제 생성
  - `@Transactional`로 선호도 등록과 문제 생성을 한 트랜잭션으로 관리
- **MemberValidator.validateAppendPreference()**
  - 최대 카테고리 개수(5개) 초과 검증 → `EXCEED_MAX_PREFERENCE_COUNT` 오류
  - 중복 선호도 검증 → `DUPLICATE_PREFERENCE` 오류
- **MemberManager**: `registerPreference()`에 `@Transactional` 추가
- **MemberReader**: `findWithLock()` 메서드로 락을 적용한 회원 조회

### 엔티티 변경
- **MemberPreference**: 메서드명 변경 `isEffectiveToday()` → `isScheduledForTomorrow()`
  - 선호도가 내일 적용될 날짜인지를 명확하게 표현
- DTO **PreferenceAppendRequest** 추가
  - `Long categoryTopicId` (`@NotNull`)
  - `ProblemDifficulty difficulty` (`@NotNull`)
  - `toNewPreference()`로 `NewPreference` 변환

### 에러 타입 확장
- `EXCEED_MAX_PREFERENCE_COUNT` (400): 최대 5개 제한 초과
- `DUPLICATE_PREFERENCE` (409): 동일한 카테고리/난이도 중복 등록
- `NOT_FOUND_MEMBER_PREFERENCE` (404): 메시지 문구 업데이트

### 테스트 추가
- 컨트롤러 테스트: 엔드포인트 유효성 검증(정상, null 필드 검증)
- 엔티티 테스트: `isScheduledForTomorrow()` 로직 검증
- 서비스 단위/통합 테스트: appendPreference 정상/예외(최대 초과, 중복) 검증
- 동시성 통합 테스트: 다중 스레드 동시 요청 시 최대 5개 제한이 유지되는지 검증

## 영향 범위
- 회원의 학습 선호도 관리 기능 전반(추가 API 및 검증 로직)
- 새 카테고리 추가 시 초기 문제 생성 흐름
- MemberPreference 관련 업데이트 로직(메서드명 변경에 따른 연쇄 영향 가능)
- 트랜잭션 및 락 사용으로 인한 DB 동시성 동작 범위

## 리뷰어 주목 포인트
- 동시성 제어: `findByIdAndStatusWithLock()`의 PESSIMISTIC_WRITE 사용으로 동시성 보장이 적절한지(락 범위, 성능 영향) 확인
- 트랜잭션 경계: `appendPreference()`와 `registerPreference()`의 `@Transactional` 중첩 동작 및 문제 생성까지의 일관성 보장 여부
- 검증 로직 순서 및 조건: 최대 개수 검사와 중복 검사 모두 활성 상태(status)를 기준으로 수행되는지, 쿼리 파라미터가 의도와 일치하는지 확인
- 메서드명 변경 영향: `isEffectiveToday()` → `isScheduledForTomorrow()` 변경에 따라 `updatePreference()` 등 호출부가 올바르게 동작하는지 확인
- 에러 타입/상태 코드 적절성: 새로 도입된 에러 코드와 메시지가 클라이언트 정책 및 API 사용성에 부합하는지 검토
- 테스트 검증: 동시성 테스트 시 스레드별 입력이 의도대로 다양하게 분산되어 있는지와 경계 조건(정확히 5개 초과 상황) 검증이 충분한지 확인
<!-- end of auto-generated comment: release notes by coderabbit.ai -->