### PR TITLE
Feat:회원 학습 설정 조회 시 다중 설정 반환 지원

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberDocsController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberDocsController.java
@@ -23,9 +23,7 @@ import org.kwakmunsu.haruhana.domain.member.service.MemberProfileResponse;
 import org.kwakmunsu.haruhana.global.annotation.LoginMember;
 import org.kwakmunsu.haruhana.global.support.response.ApiResponse;
 import org.kwakmunsu.haruhana.global.swagger.ApiExceptions;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Member Docs", description = "Member 관련 API 문서")

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/repository/MemberPreferenceJpaRepository.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/repository/MemberPreferenceJpaRepository.java
@@ -20,6 +20,9 @@ public interface MemberPreferenceJpaRepository extends JpaRepository<MemberPrefe
     Optional<MemberPreference> findByMemberIdAndStatus(Long memberId, EntityStatus status);
 
     @Query("SELECT mp FROM MemberPreference mp JOIN FETCH mp.member m JOIN FETCH mp.categoryTopic WHERE m.id = :memberId AND mp.status = :status")
+    List<MemberPreference> findAllByMemberIdWithMember(@Param("memberId") Long memberId, @Param("status") EntityStatus status);
+
+    @Query("SELECT mp FROM MemberPreference mp JOIN FETCH mp.member m JOIN FETCH mp.categoryTopic WHERE m.id = :memberId AND mp.status = :status")
     Optional<MemberPreference> findByMemberIdWithMember(@Param("memberId") Long memberId, @Param("status") EntityStatus status);
 
     @Modifying

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberProfileResponse.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberProfileResponse.java
@@ -2,6 +2,7 @@ package org.kwakmunsu.haruhana.domain.member.service;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 import org.kwakmunsu.haruhana.domain.member.entity.Member;
 import org.kwakmunsu.haruhana.domain.member.entity.MemberPreference;
@@ -18,32 +19,50 @@ public record MemberProfileResponse(
         @Schema(description = "회원 가입 일시")
         LocalDateTime createdAt,
 
-        @Schema(description = "학습 카테고리 주제 이름", example = "자료구조")
-        String categoryTopicName,
-
-        @Schema(description = "학습 문제 난이도", example = "EASY")
-        String difficulty,
-
         @Schema(description = "회원 역할", example = "ROLE_MEMBER")
         String role,
 
         @Schema(description = "조회용 presignedUrl", example = "https://example.com/profile-image.jpg")
-        String profileImageUrl
+        String profileImageUrl,
+
+        @Schema(description = "회원 선호 학습 정보 목록")
+        List<MemberPreferenceResponse> memberPreferences
 ) {
 
-    public static MemberProfileResponse from(MemberPreference memberPreference, String profileImageUrl) {
-        // NOTE: fetch join 사용으로 N + 1 문제 안터져요!
-        Member member = memberPreference.getMember();
+    public static MemberProfileResponse of(Member member, List<MemberPreference> memberPreference, String profileImageUrl) {
+        List<MemberPreferenceResponse> memberPreferenceResponses = memberPreference.stream()
+                .map(MemberPreferenceResponse::from)
+                .toList();
 
         return MemberProfileResponse.builder()
                 .loginId(member.getLoginId())
                 .nickname(member.getNickname())
                 .createdAt(member.getCreatedAt())
-                .categoryTopicName(memberPreference.getCategoryTopic().getName())
-                .difficulty(memberPreference.getDifficulty().name())
                 .role(member.getRole().name())
                 .profileImageUrl(profileImageUrl)
+                .memberPreferences(memberPreferenceResponses)
                 .build();
+    }
+
+    @Builder
+    public record MemberPreferenceResponse(
+            @Schema(description = "학습 정보 id", example = "1")
+            Long preferenceId,
+
+            @Schema(description = "학습 카테고리 주제 이름", example = "자료구조")
+            String categoryTopicName,
+
+            @Schema(description = "학습 문제 난이도", example = "EASY")
+            String difficulty
+    ) {
+
+        public static MemberPreferenceResponse from(MemberPreference memberPreference) {
+            return MemberPreferenceResponse.builder()
+                    .preferenceId(memberPreference.getId())
+                    .categoryTopicName(memberPreference.getCategoryTopic().getName())
+                    .difficulty(memberPreference.getDifficulty().name())
+                    .build();
+        }
     }
 
 }

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberReader.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberReader.java
@@ -51,7 +51,7 @@ public class MemberReader {
      * 특정 날짜 범위에 제출 기록이 없는 회원들을 조회합니다.
      *
      * @param startOfDay 조회 시작 시간 (포함)
-     * @param endOfDay 조회 종료 시간 (제외)
+     * @param endOfDay   조회 종료 시간 (제외)
      * @return 제출 기록이 없는 활성 회원 목록
      */
     public List<Member> findMembersWithoutSubmissionBetween(LocalDateTime startOfDay, LocalDateTime endOfDay) {
@@ -67,10 +67,23 @@ public class MemberReader {
         return memberPreferenceJpaRepository.findAllByEffectiveAtLessThanEqualAndStatus(targetDate, EntityStatus.ACTIVE);
     }
 
+    // NOTE: 삭제 예정 컴파일 에러를 방지하기 위해 남겨둔 메서드입니다. 추후 제거 예정입니다.
     public MemberPreference getMemberPreference(Long memberId) {
-        // 회원과 회원 정보는 라이프 사이클이 같기에 예외를 그냥 NOT_FOUND_MEMBER 로 통일
-        return memberPreferenceJpaRepository.findByMemberIdWithMember(memberId, EntityStatus.ACTIVE)
-                .orElseThrow(() -> new HaruHanaException(ErrorType.NOT_FOUND_MEMBER));
+        return memberPreferenceJpaRepository.findByMemberIdWithMember(
+                memberId,
+                EntityStatus.ACTIVE
+        ).orElseThrow(() -> new HaruHanaException(ErrorType.NOT_FOUND_MEMBER_PREFERENCE));
+    }
+
+    public List<MemberPreference> getMemberPreferences(Long memberId) {
+        List<MemberPreference> memberPreferences = memberPreferenceJpaRepository.findAllByMemberIdWithMember(
+                memberId,
+                EntityStatus.ACTIVE
+        );
+        if (memberPreferences.isEmpty()) {
+            throw new HaruHanaException(ErrorType.NOT_FOUND_MEMBER_PREFERENCE);
+        }
+        return memberPreferences;
     }
 
     public Member findByRefreshToken(String refreshToken) {

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberService.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package org.kwakmunsu.haruhana.domain.member.service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.kwakmunsu.haruhana.domain.member.entity.Member;
@@ -59,14 +60,15 @@ public class MemberService {
 
     public MemberProfileResponse getProfile(Long memberId) {
         // memberPreference를 통해 회원 정보와 선호 학습 정보를 함께 조회
-        MemberPreference memberPreference = memberReader.getMemberPreference(memberId);
+        List<MemberPreference> memberPreferences = memberReader.getMemberPreferences(memberId);
 
-        String profileImageObjectKey = memberPreference.getMember().getProfileImageObjectKey();
+        Member member = memberPreferences.getFirst().getMember();
+        String profileImageObjectKey = member.getProfileImageObjectKey();
         String presignedReadUrl = profileImageObjectKey != null
                 ? storageProvider.generatePresignedReadUrl(profileImageObjectKey)
                 : null;
 
-        return MemberProfileResponse.from(memberPreference, presignedReadUrl);
+        return MemberProfileResponse.of(member, memberPreferences,  presignedReadUrl);
     }
 
     /**

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/controller/MemberControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.kwakmunsu.haruhana.ControllerTestSupport;
 import org.kwakmunsu.haruhana.domain.member.MemberFixture;
@@ -18,6 +19,7 @@ import org.kwakmunsu.haruhana.domain.member.controller.dto.PreferenceUpdateReque
 import org.kwakmunsu.haruhana.domain.member.controller.dto.ProfileUpdateRequest;
 import org.kwakmunsu.haruhana.domain.member.enums.Role;
 import org.kwakmunsu.haruhana.domain.member.service.MemberProfileResponse;
+import org.kwakmunsu.haruhana.domain.member.service.MemberProfileResponse.MemberPreferenceResponse;
 import org.kwakmunsu.haruhana.domain.problem.enums.ProblemDifficulty;
 import org.kwakmunsu.haruhana.security.annotation.TestMember;
 import org.springframework.http.HttpStatus;
@@ -53,10 +55,14 @@ class MemberControllerTest extends ControllerTestSupport {
                 "loginId",
                 "nickname",
                 LocalDateTime.now(),
-                "알고리즘",
-                ProblemDifficulty.EASY.name(),
                 Role.ROLE_MEMBER.name(),
-                null
+                null,
+                List.of(MemberPreferenceResponse.builder()
+                        .preferenceId(1L)
+                        .categoryTopicName("자료구조")
+                        .difficulty(ProblemDifficulty.EASY.name())
+                        .build()
+                )
         );
         given(memberService.getProfile(any())).willReturn(memberProfileResponse);
 
@@ -67,8 +73,10 @@ class MemberControllerTest extends ControllerTestSupport {
                 .bodyJson()
                 .hasPathSatisfying("$.data.loginId", v -> v.assertThat().isEqualTo(memberProfileResponse.loginId()))
                 .hasPathSatisfying("$.data.nickname", v -> v.assertThat().isEqualTo(memberProfileResponse.nickname()))
-                .hasPathSatisfying("$.data.categoryTopicName", v -> v.assertThat().isEqualTo(memberProfileResponse.categoryTopicName()))
-                .hasPathSatisfying("$.data.difficulty", v -> v.assertThat().isEqualTo(memberProfileResponse.difficulty()))
+                .hasPathSatisfying("$.data.memberPreferences[0].categoryTopicName",
+                        v -> v.assertThat().isEqualTo(memberProfileResponse.memberPreferences().getFirst().categoryTopicName()))
+                .hasPathSatisfying("$.data.memberPreferences[0].difficulty",
+                        v -> v.assertThat().isEqualTo(memberProfileResponse.memberPreferences().getFirst().difficulty()))
                 .hasPathSatisfying("$.data.role", v -> v.assertThat().isEqualTo(memberProfileResponse.role()));
     }
 
@@ -145,7 +153,6 @@ class MemberControllerTest extends ControllerTestSupport {
                 .hasPathSatisfying("$.data", v -> v.assertThat().isEqualTo(true))
                 .hasPathSatisfying("$.error", v -> v.assertThat().isNull());
 
-
         // then
         verify(memberService, times(1)).checkNicknameAvailable("사용가능한닉네임");
     }
@@ -180,7 +187,7 @@ class MemberControllerTest extends ControllerTestSupport {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestJson))
                 .apply(print())
-                .hasStatus(HttpStatus.CREATED);
+                .hasStatusOk();
 
         verify(memberService, times(1)).appendPreference(any(), any());
     }

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/repository/MemberPreferenceJpaRepositoryTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/repository/MemberPreferenceJpaRepositoryTest.java
@@ -36,18 +36,39 @@ class MemberPreferenceJpaRepositoryTest extends IntegrationTestSupport{
     }
 
     @Test
-    void findByMemberIdWithMember_JOIN_FETCH_확인() {
+    void findAllByMemberIdWithMember_JOIN_FETCH_확인() {
         // given
-        var member = memberJpaRepository.save( MemberFixture.createMemberWithOutId(Role.ROLE_MEMBER));
+        var member = memberJpaRepository.save(MemberFixture.createMemberWithOutId(Role.ROLE_MEMBER));
         var memberPreference = MemberPreference.create(member, categoryTopic, ProblemDifficulty.MEDIUM, LocalDate.now());
         memberPreferenceJpaRepository.save(memberPreference);
 
         // when
-        var foundMemberPreference = memberPreferenceJpaRepository.findByMemberIdWithMember(member.getId(), EntityStatus.ACTIVE)
-                .orElseThrow();
+        var foundMemberPreferences = memberPreferenceJpaRepository.findAllByMemberIdWithMember(member.getId(), EntityStatus.ACTIVE);
 
         // then
-        assertThat(foundMemberPreference.getMember()).isEqualTo(member);
+        assertThat(foundMemberPreferences).hasSize(1)
+                .extracting(MemberPreference::getMember)
+                .containsExactly(member);
+    }
+
+    @Test
+    void findAllByMemberIdWithMember_다중_선호_학습_정보를_모두_반환한다() {
+        // given
+        var member = memberJpaRepository.save(MemberFixture.createMemberWithOutId(Role.ROLE_MEMBER));
+        var javaCategory = categoryTopic;
+        var springCategory = categoryTopicJpaRepository.findByName("Spring")
+                .orElseThrow(() -> new RuntimeException("Spring 토픽이 존재하지 않습니다"));
+
+        memberPreferenceJpaRepository.save(MemberPreference.create(member, javaCategory, ProblemDifficulty.MEDIUM, LocalDate.now()));
+        memberPreferenceJpaRepository.save(MemberPreference.create(member, springCategory, ProblemDifficulty.HARD, LocalDate.now()));
+
+        // when
+        var foundMemberPreferences = memberPreferenceJpaRepository.findAllByMemberIdWithMember(member.getId(), EntityStatus.ACTIVE);
+
+        // then
+        assertThat(foundMemberPreferences).hasSize(2)
+                .extracting(MemberPreference::getMember)
+                .containsOnly(member);
     }
 
 }

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/repository/MemberPreferenceJpaRepositoryTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/repository/MemberPreferenceJpaRepositoryTest.java
@@ -1,6 +1,7 @@
 package org.kwakmunsu.haruhana.domain.member.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
 
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 @RequiredArgsConstructor
-class MemberPreferenceJpaRepositoryTest extends IntegrationTestSupport{
+class MemberPreferenceJpaRepositoryTest extends IntegrationTestSupport {
 
     final MemberPreferenceJpaRepository memberPreferenceJpaRepository;
     final MemberJpaRepository memberJpaRepository;
@@ -43,7 +44,8 @@ class MemberPreferenceJpaRepositoryTest extends IntegrationTestSupport{
         memberPreferenceJpaRepository.save(memberPreference);
 
         // when
-        var foundMemberPreferences = memberPreferenceJpaRepository.findAllByMemberIdWithMember(member.getId(), EntityStatus.ACTIVE);
+        var foundMemberPreferences = memberPreferenceJpaRepository.findAllByMemberIdWithMember(member.getId(),
+                EntityStatus.ACTIVE);
 
         // then
         assertThat(foundMemberPreferences).hasSize(1)
@@ -59,16 +61,25 @@ class MemberPreferenceJpaRepositoryTest extends IntegrationTestSupport{
         var springCategory = categoryTopicJpaRepository.findByName("Spring")
                 .orElseThrow(() -> new RuntimeException("Spring 토픽이 존재하지 않습니다"));
 
-        memberPreferenceJpaRepository.save(MemberPreference.create(member, javaCategory, ProblemDifficulty.MEDIUM, LocalDate.now()));
-        memberPreferenceJpaRepository.save(MemberPreference.create(member, springCategory, ProblemDifficulty.HARD, LocalDate.now()));
+        memberPreferenceJpaRepository.save(
+                MemberPreference.create(member, javaCategory, ProblemDifficulty.MEDIUM, LocalDate.now()));
+        memberPreferenceJpaRepository.save(
+                MemberPreference.create(member, springCategory, ProblemDifficulty.HARD, LocalDate.now()));
 
         // when
-        var foundMemberPreferences = memberPreferenceJpaRepository.findAllByMemberIdWithMember(member.getId(), EntityStatus.ACTIVE);
+        var foundMemberPreferences = memberPreferenceJpaRepository.findAllByMemberIdWithMember(member.getId(),
+                EntityStatus.ACTIVE);
 
         // then
         assertThat(foundMemberPreferences).hasSize(2)
-                .extracting(MemberPreference::getMember)
-                .containsOnly(member);
+                .extracting(mp -> tuple(
+                        mp.getCategoryTopic().getName(),
+                        mp.getDifficulty()
+                ))
+                .containsExactlyInAnyOrder(
+                        tuple("Java", ProblemDifficulty.MEDIUM),
+                        tuple("Spring", ProblemDifficulty.HARD)
+                );
     }
 
 }

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberServiceUnitTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberServiceUnitTest.java
@@ -1,6 +1,7 @@
 package org.kwakmunsu.haruhana.domain.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -9,6 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.kwakmunsu.haruhana.UnitTestSupport;
 import org.kwakmunsu.haruhana.domain.category.entity.CategoryTopic;
@@ -62,12 +64,13 @@ class MemberServiceUnitTest extends UnitTestSupport {
     void 회원_프로필을_조회한다() {
         // given
         var member = MemberFixture.createMember(Role.ROLE_MEMBER);
-        var memberPreference = MemberPreference.create(member, CategoryTopic.create(1L, "알고리즘"), ProblemDifficulty.EASY, LocalDate.now());
+        var spring = MemberPreference.create(member, CategoryTopic.create(1L, "spring"), ProblemDifficulty.EASY, LocalDate.now());
+        var network = MemberPreference.create(member, CategoryTopic.create(2L, "네트워크"), ProblemDifficulty.EASY, LocalDate.now());
 
         member.updateProfileImageObjectKey("profile-image-key");
         var profileImageUrl = "https://presigned-url.com/profile-image";
 
-        given(memberReader.getMemberPreference(member.getId())).willReturn(memberPreference);
+        given(memberReader.getMemberPreferences(member.getId())).willReturn(List.of(spring, network));
         given(storageProvider.generatePresignedReadUrl(member.getProfileImageObjectKey())).willReturn(profileImageUrl);
 
         // when
@@ -78,15 +81,25 @@ class MemberServiceUnitTest extends UnitTestSupport {
                 .extracting(
                         MemberProfileResponse::loginId,
                         MemberProfileResponse::nickname,
-                        MemberProfileResponse::categoryTopicName,
-                        MemberProfileResponse::difficulty,
                         MemberProfileResponse::profileImageUrl
                 ).containsExactly(
                         member.getLoginId(),
                         member.getNickname(),
-                        memberPreference.getCategoryTopic().getName(),
-                        memberPreference.getDifficulty().name(),
                         profileImageUrl
+                );
+        assertThat(memberProfileResponse.memberPreferences()).hasSize(2)
+                .extracting(
+                        MemberProfileResponse.MemberPreferenceResponse::categoryTopicName,
+                        MemberProfileResponse.MemberPreferenceResponse::difficulty
+                ).containsExactly(
+                        tuple(
+                                spring.getCategoryTopic().getName(),
+                                spring.getDifficulty().name()
+                        ),
+                        tuple(
+                                network.getCategoryTopic().getName(),
+                                network.getDifficulty().name()
+                        )
                 );
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`: #195 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 한 줄 요약
회원의 학습 설정 조회 시 단일 설정만 반환하던 기존 로직을 다중 설정 반환 지원으로 변경하며, 이에 필요한 리포지토리, 서비스, 응답 DTO를 수정함

## 변경 내용

**데이터 조회 계층 변경**
- `MemberPreferenceJpaRepository`에 새로운 메소드 `findAllByMemberIdWithMember()` 추가: 특정 회원의 모든 활성 학습 설정을 한 번에 조회할 수 있으며, 관련 회원 정보와 카테고리 토픽을 eager fetch하여 N+1 쿼리 문제를 방지

**서비스 계층 변경**
- `MemberReader`에 `getMemberPreferences()` 메소드 추가: 회원의 모든 활성 학습 설정을 리스트로 반환하며, 설정이 없을 경우 `NOT_FOUND_MEMBER_PREFERENCE` 예외 발생
- 기존 `getMemberPreference()` 메소드의 예외 타입을 `NOT_FOUND_MEMBER`에서 `NOT_FOUND_MEMBER_PREFERENCE`로 변경하여 더 정확한 오류 정보 제공
- `MemberService#getProfile()`의 로직을 수정하여 단일 설정 대신 다중 설정 리스트를 조회하고, 첫 번째 설정에서 회원 정보와 프로필 이미지를 추출하여 처리

**응답 DTO 구조 변경**
- `MemberProfileResponse` 최상위 레벨에서 개별 `categoryTopicName`, `difficulty` 필드 제거
- 새로운 nested record `MemberPreferenceResponse` 도입: `preferenceId`, `categoryTopicName`, `difficulty` 필드 포함
- `memberPreferences` 필드를 `List<MemberPreferenceResponse>` 타입으로 추가하여 여러 학습 설정을 반환 가능하게 변경
- 팩토리 메소드를 `from(MemberPreference, String)` → `of(Member, List<MemberPreference>, String)`로 변경

**코드 정리**
- `MemberDocsController.java`에서 사용하지 않는 `HttpStatus`, `PostMapping` import 제거

**테스트 업데이트**
- 단위 테스트와 통합 테스트 모두 다중 설정 반환 구조에 맞춰 수정
- `MemberPreferenceJpaRepositoryTest`에서 기존 단일 조회 테스트를 다중 조회 테스트로 변경하고, 동일 회원의 여러 설정 조회를 검증하는 추가 테스트 포함
- 컨트롤러 테스트에서 `memberPreferences[0]` 배열 인덱싱으로 첫 번째 설정의 정보 검증

## 영향 범위

- **회원 프로필 조회 API**: 응답 구조가 변경되어, 클라이언트는 `memberPreferences` 배열에서 여러 학습 설정에 접근하게 됨
- **회원 학습 선호도 도메인**: 회원 1명이 여러 개의 학습 설정을 가질 수 있도록 지원하는 데이터 구조로 확장
- **데이터 조회 성능**: eager fetch를 통해 N+1 쿼리 문제 해결

## 리뷰어 주목 포인트

1. **쿼리 성능**: `findAllByMemberIdWithMember()`에서 `member`와 `categoryTopic`을 fetch하는 구문이 올바르게 작성되어 있는지 확인 필요 (eager fetch 조건)
2. **예외 처리의 일관성**: `getMemberPreference()`와 `getMemberPreferences()` 메소드 모두 같은 예외(`NOT_FOUND_MEMBER_PREFERENCE`)를 사용하는데, 단수 메소드는 컬렉션이 아닌 경우에도 같은 예외를 던지는지 확인 필요
3. **리스트 빈 체크**: `MemberService#getProfile()`에서 `memberPreferences.getFirst()`를 호출하기 전에 리스트가 비어있지 않음이 보장되었는지 확인 (서비스 계층의 `getMemberPreferences()`에서 빈 리스트를 예외로 처리하므로 문제없음)
4. **API 호환성**: 응답 구조 변경으로 인한 기존 클라이언트 호환성 영향 검토 필요
5. **다중 설정 비즈니스 로직**: 여러 학습 설정이 반환될 때, 클라이언트에서 어떻게 사용할 예정인지 확인 (예: 우선순위, 선택 로직 등)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->