### PR TITLE
Feat: 회원 학습 설정 수정 시 특정 학습 정보 수정하도록 변경

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberController.java
@@ -18,6 +18,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -45,20 +46,19 @@ public class MemberController extends MemberDocsController {
             @RequestBody @Valid PreferenceAppendRequest request,
             @LoginMember Long memberId
     ) {
-
         memberService.appendPreference(request.toNewPreference(), memberId);
 
         return ResponseEntity.ok(ApiResponse.success());
-
     }
 
     @Override
-    @PatchMapping("/v1/members/preferences")
+    @PatchMapping("/v1/members/preferences/{preferenceId}")
     public ResponseEntity<ApiResponse<?>> updatePreference(
             @RequestBody @Valid PreferenceUpdateRequest request,
+            @PathVariable Long preferenceId,
             @LoginMember Long memberId
     ) {
-        memberService.updatePreference(request.toUpdatePreference(), memberId);
+        memberService.updatePreference(request.toUpdatePreference(preferenceId), memberId);
 
         return ResponseEntity.ok(ApiResponse.success());
     }

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberDocsController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/MemberDocsController.java
@@ -24,6 +24,7 @@ import org.kwakmunsu.haruhana.global.annotation.LoginMember;
 import org.kwakmunsu.haruhana.global.support.response.ApiResponse;
 import org.kwakmunsu.haruhana.global.swagger.ApiExceptions;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Member Docs", description = "Member 관련 API 문서")
@@ -62,6 +63,7 @@ public abstract class MemberDocsController {
     })
     public abstract ResponseEntity<ApiResponse<?>> updatePreference(
             @Valid PreferenceUpdateRequest request,
+            Long preferenceId,
             Long memberId
     );
 

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/dto/PreferenceUpdateRequest.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/controller/dto/PreferenceUpdateRequest.java
@@ -16,8 +16,12 @@ public record PreferenceUpdateRequest(
         ProblemDifficulty difficulty
 ) {
 
-    public UpdatePreference toUpdatePreference() {
-        return new UpdatePreference(categoryTopicId, difficulty);
+    public UpdatePreference toUpdatePreference(Long preferenceId) {
+        return UpdatePreference.builder()
+                .preferenceId(preferenceId)
+                .categoryTopicId(categoryTopicId)
+                .difficulty(difficulty)
+                .build();
     }
 
 }

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/repository/MemberPreferenceJpaRepository.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/repository/MemberPreferenceJpaRepository.java
@@ -22,8 +22,7 @@ public interface MemberPreferenceJpaRepository extends JpaRepository<MemberPrefe
     @Query("SELECT mp FROM MemberPreference mp JOIN FETCH mp.member m JOIN FETCH mp.categoryTopic WHERE m.id = :memberId AND mp.status = :status")
     List<MemberPreference> findAllByMemberIdWithMember(@Param("memberId") Long memberId, @Param("status") EntityStatus status);
 
-    @Query("SELECT mp FROM MemberPreference mp JOIN FETCH mp.member m JOIN FETCH mp.categoryTopic WHERE m.id = :memberId AND mp.status = :status")
-    Optional<MemberPreference> findByMemberIdWithMember(@Param("memberId") Long memberId, @Param("status") EntityStatus status);
+    Optional<MemberPreference> findByIdAndMemberIdAndStatus(Long id, Long memberId, EntityStatus status);
 
     @Modifying
     @Query("UPDATE MemberPreference mp SET mp.status = :status, mp.updatedAt = :now WHERE mp.member.id = :memberId AND mp.status = 'ACTIVE'")

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberReader.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberReader.java
@@ -67,9 +67,9 @@ public class MemberReader {
         return memberPreferenceJpaRepository.findAllByEffectiveAtLessThanEqualAndStatus(targetDate, EntityStatus.ACTIVE);
     }
 
-    // NOTE: 삭제 예정 컴파일 에러를 방지하기 위해 남겨둔 메서드입니다. 추후 제거 예정입니다.
-    public MemberPreference getMemberPreference(Long memberId) {
-        return memberPreferenceJpaRepository.findByMemberIdWithMember(
+    public MemberPreference getMemberPreference(Long preferenceId, Long memberId) {
+        return memberPreferenceJpaRepository.findByIdAndMemberIdAndStatus(
+                preferenceId,
                 memberId,
                 EntityStatus.ACTIVE
         ).orElseThrow(() -> new HaruHanaException(ErrorType.NOT_FOUND_MEMBER_PREFERENCE));

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberService.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberService.java
@@ -118,18 +118,18 @@ public class MemberService {
     * */
     @Transactional
     public void updatePreference(UpdatePreference updatePreference, Long memberId) {
-        MemberPreference memberPreference = memberReader.getMemberPreference(memberId);
+        MemberPreference memberPreference = memberReader.getMemberPreference(updatePreference.preferenceId(), memberId);
 
         // 기존 선호 학습 정보와 동일한 경우 업데이트하지 않음
         if (memberPreference.isEqualsPreference(updatePreference.categoryTopicId(), updatePreference.difficulty())) {
-            log.debug("[MemberService] 선호도 변경 없음 - memberId: {}", memberId);
+            log.debug("[MemberService] 선호도 변경 없음 - memberId: {}, preferenceId: {}", memberId, updatePreference.preferenceId());
             return;
         }
 
         memberManager.updatePreference(memberPreference, updatePreference);
 
-        log.info("[MemberService] 학습 선호도 업데이트 완료 - memberId: {}, categoryTopicId: {}, difficulty: {}",
-                memberId, updatePreference.categoryTopicId(), updatePreference.difficulty());
+        log.info("[MemberService] 학습 선호도 업데이트 완료 - memberId: {}, preferenceId: {} categoryTopicId: {}, difficulty: {}",
+                memberId, updatePreference.preferenceId(), updatePreference.categoryTopicId(), updatePreference.difficulty());
     }
 
     /**

--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/service/dto/request/UpdatePreference.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/service/dto/request/UpdatePreference.java
@@ -5,6 +5,7 @@ import org.kwakmunsu.haruhana.domain.problem.enums.ProblemDifficulty;
 
 @Builder
 public record UpdatePreference(
+        Long preferenceId,
         Long categoryTopicId,
         ProblemDifficulty difficulty
 ) {

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/controller/MemberControllerTest.java
@@ -88,7 +88,7 @@ class MemberControllerTest extends ControllerTestSupport {
         String requestJson = objectMapper.writeValueAsString(request);
 
         // when & then
-        assertThat(mvcTester.patch().uri("/v1/members/preferences")
+        assertThat(mvcTester.patch().uri("/v1/members/preferences/{preferenceId}", 1L)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestJson))
                 .apply(print())

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberManagerIntegrationTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberManagerIntegrationTest.java
@@ -120,7 +120,12 @@ class MemberManagerIntegrationTest extends IntegrationTestSupport {
         memberManager.updatePreference(memberPreference, updatePreference);
 
         // then
-        var newMemberPreference = memberReader.getMemberPreferences(member.getId()).getFirst();
+        entityManager.flush();
+        entityManager.clear();
+        var newMemberPreference = memberReader.getMemberPreferences(member.getId()).stream()
+                .filter(preference -> preference.getEffectiveAt().equals(LocalDate.now().plusDays(1)))
+                .findFirst()
+                .orElseThrow();
         assertThat(newMemberPreference).isNotNull()
                 .extracting(
                         MemberPreference::getCategoryTopic,
@@ -152,7 +157,12 @@ class MemberManagerIntegrationTest extends IntegrationTestSupport {
         memberManager.updatePreference(memberPreference, updatePreference);
 
         // 같은 날짜에 두번째 업데이트 준비
-        var newMemberPreference = memberReader.getMemberPreferences(member.getId()).getFirst();
+        entityManager.flush();
+        entityManager.clear();
+        var newMemberPreference = memberReader.getMemberPreferences(member.getId()).stream()
+                .filter(preference -> preference.getEffectiveAt().equals(LocalDate.now().plusDays(1)))
+                .findFirst()
+                .orElseThrow();
         var mysqlCategory = categoryTopicJpaRepository.findByName("MySQL")
                 .orElseThrow(() -> new RuntimeException("MySQL 토픽이 존재하지 않습니다"));
         var updateSecPreference = new UpdatePreference(newMemberPreference.getId(), mysqlCategory.getId(), ProblemDifficulty.EASY);
@@ -161,11 +171,13 @@ class MemberManagerIntegrationTest extends IntegrationTestSupport {
         memberManager.updatePreference(newMemberPreference, updateSecPreference);
 
         // then
+        entityManager.flush();
+        entityManager.clear();
         var sameIdPreference = memberReader.getMemberPreference(newMemberPreference.getId(), member.getId());
 
         // 동일한 엔티티가 업데이트 되었는지 확인
         assertThat(sameIdPreference.getId()).isEqualTo(newMemberPreference.getId());
-        assertThat(newMemberPreference).isNotNull()
+        assertThat(sameIdPreference).isNotNull()
                 .extracting(
                         MemberPreference::getCategoryTopic,
                         MemberPreference::getDifficulty,

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberManagerIntegrationTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberManagerIntegrationTest.java
@@ -101,7 +101,7 @@ class MemberManagerIntegrationTest extends IntegrationTestSupport {
         var memberPreference = memberManager.registerPreference(member, newPreference);
         entityManager.flush();
 
-        var oldMemberPreference = memberReader.getMemberPreference(member.getId());
+        var oldMemberPreference = memberReader.getMemberPreference(memberPreference.getId(), member.getId());
 
         assertThat(oldMemberPreference).isNotNull().extracting(
                 MemberPreference::getCategoryTopic,
@@ -114,13 +114,13 @@ class MemberManagerIntegrationTest extends IntegrationTestSupport {
         var springCategory = categoryTopicJpaRepository.findByName("Spring")
                 .orElseThrow(() -> new RuntimeException("Spring 토픽이 존재하지 않습니다"));
 
-        var updatePreference = new UpdatePreference(springCategory.getId(), ProblemDifficulty.HARD);
+        var updatePreference = new UpdatePreference(memberPreference.getId(), springCategory.getId(), ProblemDifficulty.HARD);
 
         // when
         memberManager.updatePreference(memberPreference, updatePreference);
 
         // then
-        var newMemberPreference = memberReader.getMemberPreference(member.getId());
+        var newMemberPreference = memberReader.getMemberPreferences(member.getId()).getFirst();
         assertThat(newMemberPreference).isNotNull()
                 .extracting(
                         MemberPreference::getCategoryTopic,
@@ -148,20 +148,20 @@ class MemberManagerIntegrationTest extends IntegrationTestSupport {
         // 첫번쨰 업데이트
         var springCategory = categoryTopicJpaRepository.findByName("Spring")
                 .orElseThrow(() -> new RuntimeException("Spring 토픽이 존재하지 않습니다"));
-        var updatePreference = new UpdatePreference(springCategory.getId(), ProblemDifficulty.HARD);
+        var updatePreference = new UpdatePreference(memberPreference.getId(), springCategory.getId(), ProblemDifficulty.HARD);
         memberManager.updatePreference(memberPreference, updatePreference);
 
         // 같은 날짜에 두번째 업데이트 준비
-        var newMemberPreference = memberReader.getMemberPreference(member.getId());
+        var newMemberPreference = memberReader.getMemberPreferences(member.getId()).getFirst();
         var mysqlCategory = categoryTopicJpaRepository.findByName("MySQL")
                 .orElseThrow(() -> new RuntimeException("MySQL 토픽이 존재하지 않습니다"));
-        var updateSecPreference = new UpdatePreference(mysqlCategory.getId(), ProblemDifficulty.EASY);
+        var updateSecPreference = new UpdatePreference(newMemberPreference.getId(), mysqlCategory.getId(), ProblemDifficulty.EASY);
 
         // when
         memberManager.updatePreference(newMemberPreference, updateSecPreference);
 
         // then
-        var sameIdPreference = memberReader.getMemberPreference(member.getId());
+        var sameIdPreference = memberReader.getMemberPreference(newMemberPreference.getId(), member.getId());
 
         // 동일한 엔티티가 업데이트 되었는지 확인
         assertThat(sameIdPreference.getId()).isEqualTo(newMemberPreference.getId());

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberServiceUnitTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberServiceUnitTest.java
@@ -108,10 +108,12 @@ class MemberServiceUnitTest extends UnitTestSupport {
         // given
         var memberPreference = mock(MemberPreference.class);
 
-        given(memberReader.getMemberPreference(any())).willReturn(memberPreference);
+        given(memberReader.getMemberPreference(any(), any())).willReturn(memberPreference);
         given(memberPreference.isEqualsPreference(any(), any())).willReturn(false);
 
-        var updatePreference = new UpdatePreference(2L, ProblemDifficulty.MEDIUM);
+        long preferenceId = 2L;
+        long categoryTopicId = 1L;
+        var updatePreference = new UpdatePreference(preferenceId, categoryTopicId, ProblemDifficulty.MEDIUM);
 
         // when
         memberService.updatePreference(updatePreference, 2L);
@@ -125,10 +127,12 @@ class MemberServiceUnitTest extends UnitTestSupport {
         // given
         var memberPreference = mock(MemberPreference.class);
 
-        given(memberReader.getMemberPreference(any())).willReturn(memberPreference);
+        given(memberReader.getMemberPreference(any(), any())).willReturn(memberPreference);
         given(memberPreference.isEqualsPreference(any(Long.class), any(ProblemDifficulty.class))).willReturn(true);
 
-        var updatePreference = new UpdatePreference(2L, ProblemDifficulty.MEDIUM);
+        long preferenceId = 2L;
+        long categoryTopicId = 1L;
+        var updatePreference = new UpdatePreference(preferenceId, categoryTopicId, ProblemDifficulty.MEDIUM);
 
         // when
         memberService.updatePreference(updatePreference, 2L);


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`: #196

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 한 줄 요약
회원 학습 설정 수정 API를 변경하여 preferenceId를 경로 변수로 받아 특정 학습 정보만 수정하도록 하도록 개선함.

## 변경 내용
- API 엔드포인트 변경
  - PATCH /v1/members/preferences → PATCH /v1/members/preferences/{preferenceId}
  - 경로 변수로 preferenceId를 받아 특정 학습 정보를 타게팅하도록 수정
- 컨트롤러 계층
  - MemberController.updatePreference 시그니처에 @PathVariable Long preferenceId 추가
  - 요청 DTO 변환 시 request.toUpdatePreference(preferenceId)를 사용하도록 변경
  - MemberDocsController의 추상 메서드 시그니처에 preferenceId 파라미터 추가
- DTO / 서비스 요청 모델
  - PreferenceUpdateRequest.toUpdatePreference(Long preferenceId)로 변경
  - UpdatePreference 레코드에 Long preferenceId 필드 추가 및 빌더로 생성하도록 변경
- 리포지토리 / 조회 로직
  - 기존 findByMemberIdWithMember(...) 제거
  - findByIdAndMemberIdAndStatus(id, memberId, status) 메서드 추가 및 사용으로 조회를 preferenceId + memberId + status로 제한
  - MemberReader.getMemberPreference(Long preferenceId, Long memberId)로 시그니처 및 조회 로직 변경
- 서비스 로직
  - MemberService.updatePreference에서 preferenceId와 memberId로 대상 MemberPreference 조회 및 비교/업데이트 수행
  - 로그 메시지에 preferenceId 포함
- 테스트
  - 컨트롤러 테스트: 요청 경로를 /v1/members/preferences/{preferenceId}로 변경
  - 통합/단위 테스트: UpdatePreference 생성 및 memberReader 목 설정을 preferenceId 포함 시그니처에 맞게 수정
  - entityManager.flush()/clear() 추가로 영속성 상태 재조회 보장

## 영향 범위
- API: 클라이언트는 수정 API 경로와 호출 방식(patch 경로 변수) 변경 적용 필요
- 회원 도메인: MemberPreference 조회/수정 흐름이 preferenceId 기준으로 좁혀짐
- 리포지토리/쿼리: 기존 JOIN FETCH 기반 조회 제거로 페치 전략/성능 영향 가능
- 테스트: 관련 단위·통합 테스트 모두 변경된 시그니처에 맞춰 조정됨

## 리뷰어 주목 포인트
1. 권한/보안 검증: findByIdAndMemberIdAndStatus가 항상 memberId 조건을 보장해 다른 회원의 preference를 수정하지 못하도록 하는지 확인
2. 페치 전략 및 성능: 기존 JOIN FETCH 제거로 인해 N+1 또는 지연 로딩 이슈가 발생하지 않는지 검토(필요시 JOIN FETCH 복원 또는 페치 최적화 검토)
3. 예외 처리: 잘못된 또는 존재하지 않는 preferenceId 입력 시 적절한 예외(ErrorType.NOT_FOUND_MEMBER_PREFERENCE)와 HTTP 응답이 발생하는지 확인
4. 트랜잭션/동시성: 여러 preference 업데이트 시 일관성 보장(트랜잭션 범위 및 동시 업데이트 상황) 확인
5. API 문서화: MemberDocsController 및 Swagger/문서에서 새 경로 변수(preferenceId)가 올바르게 노출되는지 검증
<!-- end of auto-generated comment: release notes by coderabbit.ai -->