### PR TITLE
Fix: 문제 생성 및 백업 할당 실패 시 오류 알림 전송 기능 추가

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGenerator.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGenerator.java
@@ -59,7 +59,8 @@ public class ProblemGenerator {
                 Problem problem = generateAndSaveProblem(group, targetDate);
                 dailyProblemManager.assignDailyProblemToMembers(problem, group.members(), targetDate);
             } catch (Exception e) {
-                log.error("[ProblemGenerator] 문제 생성 실패 - 카테고리: {}, 난이도: {}", group.key().categoryTopicName(), group.key().difficulty(), e);
+                log.error("[ProblemGenerator] 문제 생성 실패 - 카테고리: {}, 난이도: {}", group.key().categoryTopicName(),
+                        group.key().difficulty(), e);
 
                 try {
                     assignBackupProblem(
@@ -70,12 +71,15 @@ public class ProblemGenerator {
                             targetDate
                     );
                 } catch (Exception backupEx) {
-                    log.error("[ProblemGenerator] 백업 문제 할당도 실패 - 카테고리: {}, 난이도: {}", group.key().categoryTopicName(), group.key().difficulty(), backupEx);
+                    log.error("[ProblemGenerator] 백업 문제 할당도 실패 - 카테고리: {}, 난이도: {}", group.key().categoryTopicName(),
+                            group.key().difficulty(), backupEx);
                     String message = String.format(
                             "[ProblemGenerator] 문제 생성 및 백업 할당 모두 실패 - 카테고리: %s, 난이도: %s",
                             group.key().categoryTopicName(), group.key().difficulty()
                     );
-                    errorNotificationSender.sendErrorNotification(message, backupEx);
+                    RuntimeException notificationEx = new RuntimeException(message, backupEx);
+                    notificationEx.addSuppressed(e); // 1차 실패 원인 보존
+                    errorNotificationSender.sendErrorNotification(message, notificationEx);
                 }
             }
         }
@@ -201,11 +205,12 @@ public class ProblemGenerator {
     ) {
         problemJpaRepository.findLeastRecentlyAssignedProblem(categoryTopicId, difficulty, EntityStatus.ACTIVE)
                 .ifPresentOrElse(backup -> {
-                    dailyProblemManager.assignDailyProblemToMembers(backup, members, targetDate);
-                    log.info("[ProblemGenerator] 백업 문제 할당 완료 - 카테고리: {}, 난이도: {}, 회원 수: {}", categoryTopicName, difficulty, members.size());
-                },
-                () -> log.warn("[ProblemGenerator] 백업 문제 없음, 할당 생략 - 카테고리: {}, 난이도: {}", categoryTopicName, difficulty)
-        );
+                            dailyProblemManager.assignDailyProblemToMembers(backup, members, targetDate);
+                            log.info("[ProblemGenerator] 백업 문제 할당 완료 - 카테고리: {}, 난이도: {}, 회원 수: {}", categoryTopicName, difficulty,
+                                    members.size());
+                        },
+                        () -> log.warn("[ProblemGenerator] 백업 문제 없음, 할당 생략 - 카테고리: {}, 난이도: {}", categoryTopicName, difficulty)
+                );
     }
 
     private void validateProblemResponse(ProblemResponse problemResponse) {

--- a/src/main/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGenerator.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGenerator.java
@@ -19,6 +19,7 @@ import org.kwakmunsu.haruhana.domain.problem.service.dto.ProblemResponse;
 import org.kwakmunsu.haruhana.global.entity.EntityStatus;
 import org.kwakmunsu.haruhana.global.support.error.ErrorType;
 import org.kwakmunsu.haruhana.global.support.error.HaruHanaException;
+import org.kwakmunsu.haruhana.global.support.notification.ErrorNotificationSender;
 import org.kwakmunsu.haruhana.infrastructure.gemini.ChatService;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -38,6 +39,7 @@ public class ProblemGenerator {
     private final ChatService chatService;
     private final ProblemJpaRepository problemJpaRepository;
     private final DailyProblemManager dailyProblemManager;
+    private final ErrorNotificationSender errorNotificationSender;
 
     @Transactional
     public void generateProblem(LocalDate targetDate) {
@@ -69,6 +71,11 @@ public class ProblemGenerator {
                     );
                 } catch (Exception backupEx) {
                     log.error("[ProblemGenerator] 백업 문제 할당도 실패 - 카테고리: {}, 난이도: {}", group.key().categoryTopicName(), group.key().difficulty(), backupEx);
+                    String message = String.format(
+                            "[ProblemGenerator] 문제 생성 및 백업 할당 모두 실패 - 카테고리: %s, 난이도: %s",
+                            group.key().categoryTopicName(), group.key().difficulty()
+                    );
+                    errorNotificationSender.sendErrorNotification(message, backupEx);
                 }
             }
         }

--- a/src/test/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGeneratorUnitTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGeneratorUnitTest.java
@@ -2,12 +2,14 @@ package org.kwakmunsu.haruhana.domain.problem.service;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.kwakmunsu.haruhana.UnitTestSupport;
 import org.kwakmunsu.haruhana.domain.category.CategoryTopicFixture;
@@ -22,6 +24,7 @@ import org.kwakmunsu.haruhana.domain.problem.entity.Problem;
 import org.kwakmunsu.haruhana.domain.problem.enums.ProblemDifficulty;
 import org.kwakmunsu.haruhana.domain.problem.repository.ProblemJpaRepository;
 import org.kwakmunsu.haruhana.domain.problem.service.dto.ProblemResponse;
+import org.kwakmunsu.haruhana.global.support.notification.ErrorNotificationSender;
 import org.kwakmunsu.haruhana.infrastructure.gemini.ChatService;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -40,6 +43,9 @@ class ProblemGeneratorUnitTest extends UnitTestSupport {
 
     @Mock
     DailyProblemManager dailyProblemManager;
+
+    @Mock
+    ErrorNotificationSender errorNotificationSender;
 
     @InjectMocks
     ProblemGenerator problemGenerator;
@@ -180,6 +186,47 @@ class ProblemGeneratorUnitTest extends UnitTestSupport {
         verify(chatService, times(2)).sendPrompt(any(), any());
         verify(problemJpaRepository, times(2)).save(any(Problem.class));
         verify(dailyProblemManager, times(2)).assignDailyProblemToMembers(any(), any(), any());
+    }
+
+    @Test
+    void 문제_생성과_백업_할당_모두_실패하면_슬랙_알림이_전송된다() {
+        // given
+        var targetDate = LocalDate.now();
+        var member = MemberFixture.createMember(Role.ROLE_MEMBER);
+        var javaTopic = CategoryTopicFixture.createCategoryTopic();
+        var pref = createPreference(member, javaTopic, ProblemDifficulty.MEDIUM, targetDate);
+
+        given(memberReader.getMemberPreferences(targetDate)).willReturn(List.of(pref));
+        given(chatService.sendPrompt(any(), any())).willThrow(new RuntimeException("AI 서비스 오류"));
+        given(problemJpaRepository.findLeastRecentlyAssignedProblem(any(), any(), any()))
+                .willThrow(new RuntimeException("백업 문제 조회 실패"));
+
+        // when
+        problemGenerator.generateProblem(targetDate);
+
+        // then
+        verify(errorNotificationSender, times(1)).sendErrorNotification(any(String.class), any(Exception.class));
+    }
+
+    @Test
+    void 문제_생성_실패_후_백업이_성공하면_슬랙_알림이_전송되지_않는다() {
+        // given
+        var targetDate = LocalDate.now();
+        var member = MemberFixture.createMember(Role.ROLE_MEMBER);
+        var javaTopic = CategoryTopicFixture.createCategoryTopic();
+        var pref = createPreference(member, javaTopic, ProblemDifficulty.MEDIUM, targetDate);
+        var backupProblem = ProblemFixture.createProblem(1L, javaTopic);
+
+        given(memberReader.getMemberPreferences(targetDate)).willReturn(List.of(pref));
+        given(chatService.sendPrompt(any(), any())).willThrow(new RuntimeException("AI 서비스 오류"));
+        given(problemJpaRepository.findLeastRecentlyAssignedProblem(any(), any(), any()))
+                .willReturn(Optional.of(backupProblem));
+
+        // when
+        problemGenerator.generateProblem(targetDate);
+
+        // then
+        verify(errorNotificationSender, never()).sendErrorNotification(any(), any());
     }
 
     private Member createMemberWithId(Long id) {


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`: #207

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 한 줄 요약
에러 알림을 전송하도록 ProblemGenerator의 예외 처리 로직을 개선하고 관련 단위 테스트를 추가함.

## 변경 내용
- ProblemGenerator.java
  - ErrorNotificationSender 의존성 주입 추가.
  - generateProblem()에서 문제 생성 실패 후 백업 할당도 실패하는 경우 기존에는 로그만 남겼으나, 변경 후에는 카테고리명·난이도를 포함한 포맷 문자열을 만들고 RuntimeException으로 래핑(원래 1차 실패 예외는 suppressed로 보존)하여 errorNotificationSender.sendErrorNotification(message, notificationEx)를 호출하도록 함.
  - 예외 관련 로그 문자열의 포맷 일부(개행·정렬) 정리.
  - assignBackupProblem()은 Optional.ifPresentOrElse를 사용해 기존 동작 유지(백업이 있으면 할당 및 로그, 없으면 경고 로그).

- ProblemGeneratorUnitTest.java
  - ErrorNotificationSender를 Mock으로 추가하고 ProblemGenerator에 주입.
  - 테스트 추가:
    - 문제 생성과 백업 조회/할당이 모두 실패할 때 sendErrorNotification(...)이 정확히 1회 호출되는지 검증.
    - 문제 생성 실패 후 백업 조회가 성공하면 sendErrorNotification(...)이 호출되지 않음을 검증.
  - 기존 테스트들은 그대로 유지되며 그룹화·예외 발생 시 나머지 그룹 계속 처리되는 동작도 검증함.

## 영향 범위
- 일일 문제 생성 및 회원별 문제 할당 흐름(ProblemGenerator.generateProblem).
- 백업 문제 조회 및 할당 로직(ProblemJpaRepository.findLeastRecentlyAssignedProblem, DailyProblemManager.assignDailyProblemToMembers).
- 외부 에러 알림 전송 시스템(ErrorNotificationSender — 예: Slack/모니터링 채널).

## 리뷰어 주목 포인트
- 에러 알림의 예외 정보: notificationEx에 2차 예외를 원인으로 래핑하고 1차 예외를 suppressed로 보존하는 방식이 운영에서 원인 파악에 충분한지 확인.
- 알림 메시지 내용(카테고리·난이도)으로 문제 원인 파악이 가능한지 여부 및 추가 컨텍스트(예: 대상 회원 수, 날짜 등) 필요성 검토.
- 트랜잭션/동시성 영향: generateProblem()의 트랜잭션 범위 내에서 예외 처리 후 assignBackupProblem() 호출이 트랜잭션 상태에 미치는 영향 확인(특히 generateInitialProblem의 REQUIRES_NEW와의 일관성).
- 테스트 커버리지: 에러 알림 호출 시점과 예외 전달 방식(예외 타입·suppressed 포함)을 충분히 검증했는지 검토.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->