### PR TITLE
Fix: 변경된 aiAnswer 및 피드백 필드의 데이터 타입을 TEXT로 수정하여 대용량 데이터 저장 가능하도록 개선

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/domain/problem/entity/Problem.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/problem/entity/Problem.java
@@ -6,7 +6,6 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
 import lombok.AccessLevel;
@@ -27,8 +26,7 @@ public class Problem extends BaseEntity {
     @Column(nullable = false)
     private String description;
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String aiAnswer;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/kwakmunsu/haruhana/domain/submission/entity/SubmissionFeedback.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/submission/entity/SubmissionFeedback.java
@@ -8,9 +8,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,16 +28,13 @@ public class SubmissionFeedback extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private FeedbackGrade grade;
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String strengths;
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String weaknesses;
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String suggestion;
 
     public static SubmissionFeedback create(


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`: #210 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 한 줄 요약
AI 답변 및 피드백 필드의 데이터 타입을 `@Lob`에서 TEXT 컬럼 타입으로 변경하여 대용량 텍스트 데이터 저장을 개선함

## 변경 내용

### Problem.java
- `aiAnswer` 필드의 매핑 방식 변경
  - 기존: `@Lob` + `@Column(nullable = false)` 조합으로 대용량 객체 저장 방식 사용
  - 변경: `@Column(nullable = false, columnDefinition = "TEXT")` 으로 MySQL TEXT 타입 명시적 지정
  - 효과: 데이터베이스 타입이 일관성 있게 TEXT 타입으로 설정되어 장문의 AI 생성 답변을 안정적으로 저장 가능

### SubmissionFeedback.java  
- 세 개의 피드백 필드의 매핑 방식 일괄 변경
  - `strengths` (강점): `@Lob` 제거 → `@Column(nullable = false, columnDefinition = "TEXT")`
  - `weaknesses` (약점): `@Lob` 제거 → `@Column(nullable = false, columnDefinition = "TEXT")`
  - `suggestion` (제안): `@Lob` 제거 → `@Column(nullable = false, columnDefinition = "TEXT")`
  - 효과: 사용자 피드백 내용이 길어도 안정적으로 저장되며, 데이터베이스 일관성 향상

## 영향 범위

- **Problem 도메인**: AI가 생성한 장문의 문제 답변 저장 기능
- **Submission/SubmissionFeedback 도메인**: 채점 및 피드백 기능에서 상세한 피드백 저장 및 조회
- **데이터베이스**: MySQL의 TEXT 컬럼 타입을 사용하는 모든 쿼리 및 ORM 매핑

## 리뷰어 주목 포인트

- **데이터베이스 마이그레이션**: 기존 `@Lob` 매핑으로 생성된 BLOB/LONGBLOB 타입 컬럼을 TEXT로 변경하는 DDL(ALTER TABLE) 스크립트 필요 여부 확인
- **컬럼 사이즈 제한**: MySQL TEXT 타입은 최대 64KB 크기 제약이 있으므로, 실제 데이터 크기가 이를 초과할 가능성이 없는지 검증 필요
- **기존 데이터 호환성**: 이전에 저장된 대용량 데이터(BLOB)가 TEXT로 변환될 때 데이터 손실이나 인코딩 문제 없는지 확인
- **ORM 쿼리 영향**: Hibernate의 LAZY LOADING 설정이 TEXT 타입에서도 동일하게 동작하는지 확인
- **성능 영향**: TEXT 타입으로의 변경이 인덱싱이나 전문 검색(Full-Text Search) 필요 시 성능에 미치는 영향 검토

<!-- end of auto-generated comment: release notes by coderabbit.ai -->