### PR TITLE
Fix: 날짜별 문제 풀이 조회시 단일 조회 오류 발생 해결

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/domain/dailyproblem/controller/DailyProblemController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/dailyproblem/controller/DailyProblemController.java
@@ -2,6 +2,7 @@ package org.kwakmunsu.haruhana.domain.dailyproblem.controller;
 
 import jakarta.validation.Valid;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.kwakmunsu.haruhana.domain.dailyproblem.controller.dto.SubmitSolutionRequest;
 import org.kwakmunsu.haruhana.domain.dailyproblem.service.DailyProblemService;
@@ -30,21 +31,21 @@ public class DailyProblemController extends DailyProblemDocsController {
 
     @Override
     @GetMapping("/v1/daily-problem/today")
-    public ResponseEntity<ApiResponse<TodayProblemResponse>> getTodayProblem(@LoginMember Long memberId) {
-        TodayProblemResponse response = dailyProblemService.getTodayProblem(memberId);
+    public ResponseEntity<ApiResponse<List<TodayProblemResponse>>> getTodayProblem(@LoginMember Long memberId) {
+        List<TodayProblemResponse> response = dailyProblemService.getTodayProblem(memberId);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @Override
     @GetMapping("/v1/daily-problem")
-    public ResponseEntity<ApiResponse<DailyProblemResponse>> findDailyProblem(
+    public ResponseEntity<ApiResponse<List<DailyProblemResponse>>> findDailyProblems(
             @RequestParam(required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
             LocalDate date,
             @LoginMember Long memberId
     ) {
-        DailyProblemResponse response = dailyProblemService.findDailyProblem(date, memberId);
+        List<DailyProblemResponse> response = dailyProblemService.findDailyProblems(date, memberId);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/org/kwakmunsu/haruhana/domain/dailyproblem/controller/DailyProblemDocsController.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/dailyproblem/controller/DailyProblemDocsController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
+import java.util.List;
 import org.kwakmunsu.haruhana.domain.dailyproblem.controller.dto.SubmitSolutionRequest;
 import org.kwakmunsu.haruhana.domain.dailyproblem.service.dto.response.DailyProblemDetailResponse;
 import org.kwakmunsu.haruhana.domain.dailyproblem.service.dto.response.DailyProblemResponse;
@@ -31,7 +32,7 @@ public abstract class DailyProblemDocsController {
             ErrorType.UNAUTHORIZED_ERROR,
             ErrorType.DEFAULT_ERROR
     })
-    public abstract ResponseEntity<ApiResponse<TodayProblemResponse>> getTodayProblem(Long memberId);
+    public abstract ResponseEntity<ApiResponse<List<TodayProblemResponse>>> getTodayProblem(Long memberId);
 
     @Operation(
             summary = "날짜에 해당하는 회원에게 할당된 데일리 문제 미리보기 조회 - JWT [O]",
@@ -46,7 +47,7 @@ public abstract class DailyProblemDocsController {
             ErrorType.UNAUTHORIZED_ERROR,
             ErrorType.DEFAULT_ERROR
     })
-    public abstract ResponseEntity<ApiResponse<DailyProblemResponse>> findDailyProblem(
+    public abstract ResponseEntity<ApiResponse<List<DailyProblemResponse>>> findDailyProblems(
             LocalDate date,
             Long memberId
     );

--- a/src/main/java/org/kwakmunsu/haruhana/domain/dailyproblem/repository/DailyProblemJpaRepository.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/dailyproblem/repository/DailyProblemJpaRepository.java
@@ -23,7 +23,7 @@ public interface DailyProblemJpaRepository extends JpaRepository<DailyProblem, L
               AND dp.status = :status
             """
     )
-    Optional<DailyProblem> findByMemberIdAndAssignedAtAndStatus(
+    List<DailyProblem> findAllByMemberIdAndAssignedAtAndStatus(
             @Param("memberId") Long memberId,
             @Param("assignedAt") LocalDate assignedAt,
             @Param("status") EntityStatus status

--- a/src/main/java/org/kwakmunsu/haruhana/domain/dailyproblem/service/DailyProblemReader.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/dailyproblem/service/DailyProblemReader.java
@@ -2,7 +2,6 @@ package org.kwakmunsu.haruhana.domain.dailyproblem.service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.kwakmunsu.haruhana.domain.dailyproblem.entity.DailyProblem;
 import org.kwakmunsu.haruhana.domain.dailyproblem.repository.DailyProblemJpaRepository;
@@ -19,12 +18,12 @@ public class DailyProblemReader {
     private final DailyProblemJpaRepository dailyProblemJpaRepository;
 
     @Transactional(readOnly = true)
-    public DailyProblem findDailyProblemByMember(Long memberId) {
-        return dailyProblemJpaRepository.findByMemberIdAndAssignedAtAndStatus(
+    public List<DailyProblem> findDailyProblemsByMember(Long memberId) {
+        return dailyProblemJpaRepository.findAllByMemberIdAndAssignedAtAndStatus(
                 memberId,
                 LocalDate.now(),
                 EntityStatus.ACTIVE
-        ).orElseThrow(() -> new HaruHanaException(ErrorType.NOT_FOUND_DAILY_PROBLEM));
+        );
     }
 
     public DailyProblem find(Long id, Long memberId) {
@@ -33,12 +32,12 @@ public class DailyProblemReader {
     }
 
     @Transactional(readOnly = true)
-    public Optional<DailyProblem> findDailyProblem(LocalDate assignedAt, Long memberId) {
+    public List<DailyProblem> findDailyProblems(LocalDate assignedAt, Long memberId) {
         if (assignedAt == null) {
             assignedAt = LocalDate.now();
         }
 
-        return dailyProblemJpaRepository.findByMemberIdAndAssignedAtAndStatus(
+        return dailyProblemJpaRepository.findAllByMemberIdAndAssignedAtAndStatus(
                 memberId,
                 assignedAt,
                 EntityStatus.ACTIVE

--- a/src/main/java/org/kwakmunsu/haruhana/domain/dailyproblem/service/DailyProblemService.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/dailyproblem/service/DailyProblemService.java
@@ -1,7 +1,7 @@
 package org.kwakmunsu.haruhana.domain.dailyproblem.service;
 
 import java.time.LocalDate;
-import java.util.Optional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.kwakmunsu.haruhana.domain.dailyproblem.entity.DailyProblem;
@@ -28,11 +28,13 @@ public class DailyProblemService {
      * @param memberId 회원 ID
      */
     @Cacheable(cacheNames = "todayProblem", key = "#memberId + ':' + T(java.time.LocalDate).now()")
-    public TodayProblemResponse getTodayProblem(Long memberId) {
+    public List<TodayProblemResponse> getTodayProblem(Long memberId) {
         log.debug("[DailyProblemService] 오늘의 문제 캐시 미스 - 조회 시작");
-        DailyProblem dailyProblem = dailyProblemReader.findDailyProblemByMember(memberId);
+        List<DailyProblem> dailyProblems = dailyProblemReader.findDailyProblemsByMember(memberId);
 
-        return TodayProblemResponse.from(dailyProblem);
+        return dailyProblems.stream()
+                .map(TodayProblemResponse::from)
+                .toList();
     }
 
     /**
@@ -60,15 +62,12 @@ public class DailyProblemService {
      * @param memberId 회원 ID returns DailyProblemResponse 데일리 문제 미리보기 응답 DTO
      *
      */
-    public DailyProblemResponse findDailyProblem(LocalDate date, Long memberId) {
-        Optional<DailyProblem> dailyProblem = dailyProblemReader.findDailyProblem(date, memberId);
+    public List<DailyProblemResponse> findDailyProblems(LocalDate date, Long memberId) {
+        List<DailyProblem> dailyProblems = dailyProblemReader.findDailyProblems(date, memberId);
 
-        if (dailyProblem.isEmpty()) {
-            log.debug("[DailyProblemService] 해당 날짜의 문제 없음 - date={}", date);
-            return DailyProblemResponse.builder().build();
-        }
-
-        return DailyProblemResponse.from(dailyProblem.get());
+        return dailyProblems.stream()
+                .map(DailyProblemResponse::from)
+                .toList();
     }
 
 }

--- a/src/test/java/org/kwakmunsu/haruhana/domain/dailyproblem/controller/DailyProblemControllerTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/dailyproblem/controller/DailyProblemControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.kwakmunsu.haruhana.ControllerTestSupport;
 import org.kwakmunsu.haruhana.domain.dailyproblem.controller.dto.SubmitSolutionRequest;
@@ -35,19 +36,19 @@ class DailyProblemControllerTest extends ControllerTestSupport {
                 false
         );
 
-        given(dailyProblemService.getTodayProblem(any())).willReturn(response);
+        given(dailyProblemService.getTodayProblem(any())).willReturn(List.of(response));
 
         // when & then
         assertThat(mvcTester.get().uri("/v1/daily-problem/today"))
                 .apply(print())
                 .hasStatusOk()
                 .bodyJson()
-                .hasPathSatisfying("data.id", v -> v.assertThat().isEqualTo(response.id().intValue()))
-                .hasPathSatisfying("data.title", v -> v.assertThat().isEqualTo(response.title()))
-                .hasPathSatisfying("data.description", v -> v.assertThat().isEqualTo(response.description()))
-                .hasPathSatisfying("data.difficulty", v -> v.assertThat().isEqualTo(response.difficulty()))
-                .hasPathSatisfying("data.categoryTopicName", v -> v.assertThat().isEqualTo(response.categoryTopicName()))
-                .hasPathSatisfying("data.isSolved", v -> v.assertThat().isEqualTo(response.isSolved()));
+                .hasPathSatisfying("data[0].id", v -> v.assertThat().isEqualTo(response.id().intValue()))
+                .hasPathSatisfying("data[0].title", v -> v.assertThat().isEqualTo(response.title()))
+                .hasPathSatisfying("data[0].description", v -> v.assertThat().isEqualTo(response.description()))
+                .hasPathSatisfying("data[0].difficulty", v -> v.assertThat().isEqualTo(response.difficulty()))
+                .hasPathSatisfying("data[0].categoryTopicName", v -> v.assertThat().isEqualTo(response.categoryTopicName()))
+                .hasPathSatisfying("data[0].isSolved", v -> v.assertThat().isEqualTo(response.isSolved()));
     }
 
     @TestMember
@@ -155,7 +156,7 @@ class DailyProblemControllerTest extends ControllerTestSupport {
                 .isSolved(false)
                 .build();
 
-        given(dailyProblemService.findDailyProblem(any(LocalDate.class), anyLong())).willReturn(response);
+        given(dailyProblemService.findDailyProblems(any(LocalDate.class), anyLong())).willReturn(List.of(response));
 
         // when & then
         assertThat(mvcTester.get().uri("/v1/daily-problem")
@@ -164,11 +165,46 @@ class DailyProblemControllerTest extends ControllerTestSupport {
                 .apply(print())
                 .hasStatusOk()
                 .bodyJson()
-                .hasPathSatisfying("data.id", v -> v.assertThat().isEqualTo(response.id().intValue()))
-                .hasPathSatisfying("data.difficulty", v -> v.assertThat().isEqualTo(response.difficulty()))
-                .hasPathSatisfying("data.categoryTopic", v -> v.assertThat().isEqualTo(response.categoryTopic()))
-                .hasPathSatisfying("data.title", v -> v.assertThat().isEqualTo(response.title()))
-                .hasPathSatisfying("data.isSolved", v -> v.assertThat().isEqualTo(false));
+                .hasPathSatisfying("data[0].id", v -> v.assertThat().isEqualTo(response.id().intValue()))
+                .hasPathSatisfying("data[0].difficulty", v -> v.assertThat().isEqualTo(response.difficulty()))
+                .hasPathSatisfying("data[0].categoryTopic", v -> v.assertThat().isEqualTo(response.categoryTopic()))
+                .hasPathSatisfying("data[0].title", v -> v.assertThat().isEqualTo(response.title()))
+                .hasPathSatisfying("data[0].isSolved", v -> v.assertThat().isEqualTo(false));
+    }
+
+    @TestMember
+    @Test
+    void 여러_카테고리의_문제를_날짜로_조회한다() {
+        // given
+        DailyProblemResponse javaResponse = DailyProblemResponse.builder()
+                .id(1L)
+                .difficulty(ProblemDifficulty.MEDIUM.name())
+                .categoryTopic("Java")
+                .title("Java의 equals와 hashCode")
+                .isSolved(false)
+                .build();
+        DailyProblemResponse springResponse = DailyProblemResponse.builder()
+                .id(2L)
+                .difficulty(ProblemDifficulty.EASY.name())
+                .categoryTopic("Spring")
+                .title("Spring IOC/DI")
+                .isSolved(true)
+                .build();
+
+        given(dailyProblemService.findDailyProblems(any(LocalDate.class), anyLong()))
+                .willReturn(List.of(javaResponse, springResponse));
+
+        // when & then
+        assertThat(mvcTester.get().uri("/v1/daily-problem")
+                .param("date", LocalDate.now().toString())
+                .contentType(MediaType.APPLICATION_JSON))
+                .apply(print())
+                .hasStatusOk()
+                .bodyJson()
+                .hasPathSatisfying("data[0].id", v -> v.assertThat().isEqualTo(javaResponse.id().intValue()))
+                .hasPathSatisfying("data[0].categoryTopic", v -> v.assertThat().isEqualTo(javaResponse.categoryTopic()))
+                .hasPathSatisfying("data[1].id", v -> v.assertThat().isEqualTo(springResponse.id().intValue()))
+                .hasPathSatisfying("data[1].categoryTopic", v -> v.assertThat().isEqualTo(springResponse.categoryTopic()));
     }
 
 }

--- a/src/test/java/org/kwakmunsu/haruhana/domain/dailyproblem/service/DailyProblemCacheTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/dailyproblem/service/DailyProblemCacheTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -71,14 +72,14 @@ class DailyProblemCacheTest extends IntegrationTestSupport {
         var problem = ProblemFixture.createProblem(CategoryTopicFixture.createCategoryTopic());
         var dailyProblem = DailyProblemFixture.createUnsolvedDailyProblem(1L, member, problem);
 
-        given(dailyProblemReader.findDailyProblemByMember(memberId)).willReturn(dailyProblem);
+        given(dailyProblemReader.findDailyProblemsByMember(memberId)).willReturn(List.of(dailyProblem));
 
         // when: 동일 회원으로 2번 조회
         dailyProblemService.getTodayProblem(memberId);
         dailyProblemService.getTodayProblem(memberId);
 
         // then: DB는 1번만 호출
-        verify(dailyProblemReader, times(1)).findDailyProblemByMember(memberId);
+        verify(dailyProblemReader, times(1)).findDailyProblemsByMember(memberId);
     }
 
     @Test
@@ -89,7 +90,7 @@ class DailyProblemCacheTest extends IntegrationTestSupport {
         var problem = ProblemFixture.createProblem(CategoryTopicFixture.createCategoryTopic());
         var dailyProblem = DailyProblemFixture.createUnsolvedDailyProblem(1L, member, problem);
 
-        given(dailyProblemReader.findDailyProblemByMember(memberId)).willReturn(dailyProblem);
+        given(dailyProblemReader.findDailyProblemsByMember(memberId)).willReturn(List.of(dailyProblem));
 
         // when
         dailyProblemService.getTodayProblem(memberId);
@@ -107,10 +108,10 @@ class DailyProblemCacheTest extends IntegrationTestSupport {
         var member = MemberFixture.createMember(Role.ROLE_MEMBER);
         var problem = ProblemFixture.createProblem(CategoryTopicFixture.createCategoryTopic());
 
-        given(dailyProblemReader.findDailyProblemByMember(memberIdA))
-                .willReturn(DailyProblemFixture.createUnsolvedDailyProblem(1L, member, problem));
-        given(dailyProblemReader.findDailyProblemByMember(memberIdB))
-                .willReturn(DailyProblemFixture.createUnsolvedDailyProblem(2L, member, problem));
+        given(dailyProblemReader.findDailyProblemsByMember(memberIdA))
+                .willReturn(List.of(DailyProblemFixture.createUnsolvedDailyProblem(1L, member, problem)));
+        given(dailyProblemReader.findDailyProblemsByMember(memberIdB))
+                .willReturn(List.of(DailyProblemFixture.createUnsolvedDailyProblem(2L, member, problem)));
 
         // when: 각각 2번씩 조회
         dailyProblemService.getTodayProblem(memberIdA);
@@ -119,8 +120,8 @@ class DailyProblemCacheTest extends IntegrationTestSupport {
         dailyProblemService.getTodayProblem(memberIdB);
 
         // then: 각 회원마다 DB는 1번씩만 호출
-        verify(dailyProblemReader, times(1)).findDailyProblemByMember(memberIdA);
-        verify(dailyProblemReader, times(1)).findDailyProblemByMember(memberIdB);
+        verify(dailyProblemReader, times(1)).findDailyProblemsByMember(memberIdA);
+        verify(dailyProblemReader, times(1)).findDailyProblemsByMember(memberIdB);
     }
 
     @Test
@@ -132,7 +133,7 @@ class DailyProblemCacheTest extends IntegrationTestSupport {
         var problem = ProblemFixture.createProblem(CategoryTopicFixture.createCategoryTopic());
         var dailyProblem = DailyProblemFixture.createUnsolvedDailyProblem(dailyProblemId, member, problem);
 
-        given(dailyProblemReader.findDailyProblemByMember(memberId)).willReturn(dailyProblem);
+        given(dailyProblemReader.findDailyProblemsByMember(memberId)).willReturn(List.of(dailyProblem));
         dailyProblemService.getTodayProblem(memberId);
 
         var cache = cacheManager.getCache("todayProblem");
@@ -151,7 +152,7 @@ class DailyProblemCacheTest extends IntegrationTestSupport {
 
         // then: 재조회 시 DB 재호출
         dailyProblemService.getTodayProblem(memberId);
-        verify(dailyProblemReader, times(2)).findDailyProblemByMember(memberId);
+        verify(dailyProblemReader, times(2)).findDailyProblemsByMember(memberId);
     }
 
     // ──────────────────────────────────────────────────────────────

--- a/src/test/java/org/kwakmunsu/haruhana/domain/dailyproblem/service/DailyProblemReaderIntegrationTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/dailyproblem/service/DailyProblemReaderIntegrationTest.java
@@ -53,12 +53,38 @@ class DailyProblemReaderIntegrationTest extends IntegrationTestSupport {
         dailyProblemJpaRepository.save(dailyProblem);
 
         // when
-        var dailyProblemOptional = dailyProblemReader.findDailyProblem(dailyProblem.getAssignedAt(), member.getId());
+        var result = dailyProblemReader.findDailyProblems(dailyProblem.getAssignedAt(), member.getId());
 
         // then
-        assertThat(dailyProblemOptional).isPresent();
-        var foundDailyProblem = dailyProblemOptional.get();
-        assertThat(foundDailyProblem.getId()).isEqualTo(dailyProblem.getId());
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getId()).isEqualTo(dailyProblem.getId());
+    }
+
+    @Test
+    void 해당날짜에_회원에게_여러_카테고리_문제가_할당된_경우_모두_조회된다() {
+        // given
+        var member = MemberFixture.createMemberWithOutId("loginId", "nickname");
+        memberJpaRepository.save(member);
+
+        var springTopic = categoryTopicJpaRepository.findByName("Spring").orElseThrow();
+
+        var javaProblem = ProblemFixture.createProblem("Java 문제", "Java 설명", categoryTopic, ProblemDifficulty.MEDIUM);
+        var springProblem = ProblemFixture.createProblem("Spring 문제", "Spring 설명", springTopic, ProblemDifficulty.EASY);
+        problemJpaRepository.save(javaProblem);
+        problemJpaRepository.save(springProblem);
+
+        var javaDailyProblem = DailyProblem.create(member, javaProblem, LocalDate.now());
+        var springDailyProblem = DailyProblem.create(member, springProblem, LocalDate.now());
+        dailyProblemJpaRepository.save(javaDailyProblem);
+        dailyProblemJpaRepository.save(springDailyProblem);
+
+        // when
+        var result = dailyProblemReader.findDailyProblems(LocalDate.now(), member.getId());
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(dp -> dp.getProblem().getCategoryTopic().getName())
+                .containsExactlyInAnyOrder("Java", "Spring");
     }
 
     @Test
@@ -75,10 +101,10 @@ class DailyProblemReaderIntegrationTest extends IntegrationTestSupport {
 
         // when
         LocalDate notExistsDailyProblemDate = LocalDate.now().plusDays(4);
-        var dailyProblemOptional = dailyProblemReader.findDailyProblem(notExistsDailyProblemDate, member.getId());
+        var result = dailyProblemReader.findDailyProblems(notExistsDailyProblemDate, member.getId());
 
         // then
-        assertThat(dailyProblemOptional).isEmpty();
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -95,10 +121,10 @@ class DailyProblemReaderIntegrationTest extends IntegrationTestSupport {
 
         // when
         Long anotherMemberId = member.getId() + 1;
-        var dailyProblemOptional = dailyProblemReader.findDailyProblem(dailyProblem.getAssignedAt(), anotherMemberId);
+        var result = dailyProblemReader.findDailyProblems(dailyProblem.getAssignedAt(), anotherMemberId);
 
         // then
-        assertThat(dailyProblemOptional).isEmpty();
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -114,12 +140,11 @@ class DailyProblemReaderIntegrationTest extends IntegrationTestSupport {
         dailyProblemJpaRepository.save(dailyProblem);
 
         // when
-        var dailyProblemOptional = dailyProblemReader.findDailyProblem(null, member.getId());
+        var result = dailyProblemReader.findDailyProblems(null, member.getId());
 
         // then
-        assertThat(dailyProblemOptional).isPresent();
-        var foundDailyProblem = dailyProblemOptional.get();
-        assertThat(foundDailyProblem.getId()).isEqualTo(dailyProblem.getId());
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getId()).isEqualTo(dailyProblem.getId());
     }
 
 }

--- a/src/test/java/org/kwakmunsu/haruhana/domain/dailyproblem/service/DailyProblemServiceUnitTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/dailyproblem/service/DailyProblemServiceUnitTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.kwakmunsu.haruhana.UnitTestSupport;
@@ -47,13 +48,14 @@ class DailyProblemServiceUnitTest extends UnitTestSupport {
         var problem = ProblemFixture.createProblem(categoryTopic);
         var dailyProblem = DailyProblemFixture.createUnsolvedDailyProblem(1L, member, problem);
 
-        given(dailyProblemReader.findDailyProblemByMember(memberId)).willReturn(dailyProblem);
+        given(dailyProblemReader.findDailyProblemsByMember(memberId)).willReturn(List.of(dailyProblem));
 
         // when
-        var response = dailyProblemService.getTodayProblem(memberId);
+        var responses = dailyProblemService.getTodayProblem(memberId);
 
         // then
-        assertThat(response).isNotNull().extracting(
+        assertThat(responses).hasSize(1);
+        assertThat(responses.getFirst()).extracting(
                 TodayProblemResponse::id,
                 TodayProblemResponse::title,
                 TodayProblemResponse::description,
@@ -69,21 +71,42 @@ class DailyProblemServiceUnitTest extends UnitTestSupport {
                 false
         );
 
-        verify(dailyProblemReader, times(1)).findDailyProblemByMember(memberId);
+        verify(dailyProblemReader, times(1)).findDailyProblemsByMember(memberId);
     }
 
     @Test
-    void 오늘의_문제가_없으면_예외를_발생시킨다() {
+    void 오늘의_문제가_여러_카테고리인_경우_모두_반환한다() {
+        // given
+        var memberId = 1L;
+        var member = MemberFixture.createMember(Role.ROLE_MEMBER);
+        var javaDailyProblem = DailyProblemFixture.createUnsolvedDailyProblem(1L, member,
+                ProblemFixture.createProblem(CategoryTopicFixture.createCategoryTopic()));
+        var springDailyProblem = DailyProblemFixture.createUnsolvedDailyProblem(2L, member,
+                ProblemFixture.createProblem(2L, CategoryTopic.create(2L, "Spring")));
+
+        given(dailyProblemReader.findDailyProblemsByMember(memberId))
+                .willReturn(List.of(javaDailyProblem, springDailyProblem));
+
+        // when
+        var responses = dailyProblemService.getTodayProblem(memberId);
+
+        // then
+        assertThat(responses).hasSize(2);
+        assertThat(responses).extracting(TodayProblemResponse::id).containsExactly(1L, 2L);
+    }
+
+    @Test
+    void 오늘의_문제가_없으면_빈_리스트를_반환한다() {
         // given
         var memberId = 1L;
 
-        given(dailyProblemReader.findDailyProblemByMember(memberId))
-                .willThrow(new HaruHanaException(ErrorType.NOT_FOUND_DAILY_PROBLEM));
+        given(dailyProblemReader.findDailyProblemsByMember(memberId)).willReturn(List.of());
 
-        // when & then
-        assertThatThrownBy(() -> dailyProblemService.getTodayProblem(memberId))
-                .isInstanceOf(HaruHanaException.class)
-                .hasMessage(ErrorType.NOT_FOUND_DAILY_PROBLEM.getMessage());
+        // when
+        var responses = dailyProblemService.getTodayProblem(memberId);
+
+        // then
+        assertThat(responses).isEmpty();
     }
 
     @Test
@@ -176,18 +199,20 @@ class DailyProblemServiceUnitTest extends UnitTestSupport {
     @Test
     void 날짜에_해당하는_할당된_문제를_조회한다() {
         // given
+        var member = MemberFixture.createMember(Role.ROLE_MEMBER);
         var dailyProblem = DailyProblemFixture.createDailyProblem(
-                MemberFixture.createMember(Role.ROLE_MEMBER),
+                member,
                 ProblemFixture.createProblem(CategoryTopic.create(1L, "Java"))
         );
 
-        given(dailyProblemReader.findDailyProblem(any(), any())).willReturn(Optional.of(dailyProblem));
+        given(dailyProblemReader.findDailyProblems(any(), any())).willReturn(List.of(dailyProblem));
 
         // when
-        var response = dailyProblemService.findDailyProblem(dailyProblem.getAssignedAt(), 1L);
+        var responses = dailyProblemService.findDailyProblems(dailyProblem.getAssignedAt(), 1L);
 
         // then
-        assertThat(response).isNotNull().extracting(
+        assertThat(responses).hasSize(1);
+        assertThat(responses.getFirst()).extracting(
                 DailyProblemResponse::id,
                 DailyProblemResponse::difficulty,
                 DailyProblemResponse::categoryTopic,
@@ -203,27 +228,35 @@ class DailyProblemServiceUnitTest extends UnitTestSupport {
     }
 
     @Test
-    void 날짜에_해당된_문제가_없다() {
+    void 날짜에_여러_카테고리_문제가_있을_경우_모두_반환한다() {
         // given
-        given(dailyProblemReader.findDailyProblem(any(), any())).willReturn(Optional.empty());
+        var member = MemberFixture.createMember(Role.ROLE_MEMBER);
+        var dailyProblem1 = DailyProblemFixture.createDailyProblem(1L, member,
+                ProblemFixture.createProblem(CategoryTopic.create(1L, "Java")));
+        var dailyProblem2 = DailyProblemFixture.createDailyProblem(2L, member,
+                ProblemFixture.createProblem(2L, CategoryTopic.create(2L, "Spring")));
+
+        given(dailyProblemReader.findDailyProblems(any(), any())).willReturn(List.of(dailyProblem1, dailyProblem2));
 
         // when
-        var response = dailyProblemService.findDailyProblem(LocalDate.now(), 1L);
+        var responses = dailyProblemService.findDailyProblems(LocalDate.now(), 1L);
 
         // then
-        assertThat(response).isNotNull().extracting(
-                DailyProblemResponse::id,
-                DailyProblemResponse::difficulty,
-                DailyProblemResponse::categoryTopic,
-                DailyProblemResponse::title,
-                DailyProblemResponse::isSolved
-        ).containsExactly(
-                null,
-                null,
-                null,
-                null,
-                false
-        );
+        assertThat(responses).hasSize(2);
+        assertThat(responses).extracting(DailyProblemResponse::id)
+                .containsExactly(dailyProblem1.getId(), dailyProblem2.getId());
+    }
+
+    @Test
+    void 날짜에_해당된_문제가_없다() {
+        // given
+        given(dailyProblemReader.findDailyProblems(any(), any())).willReturn(List.of());
+
+        // when
+        var responses = dailyProblemService.findDailyProblems(LocalDate.now(), 1L);
+
+        // then
+        assertThat(responses).isEmpty();
     }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`:  #212 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 한 줄 요약
날짜별 문제 풀이 조회 시 동일 날짜의 여러 문제를 조회할 수 있도록 단일 반환에서 리스트 반환으로 변경함

## 변경 내용

### 리포지토리 계층
- `DailyProblemJpaRepository.findByMemberIdAndAssignedAtAndStatus` 메서드명을 `findAllByMemberIdAndAssignedAtAndStatus`로 변경하고, 반환 타입을 `Optional<DailyProblem>`에서 `List<DailyProblem>`으로 변경
- 동일한 JPQL 쿼리와 파라미터를 유지하면서 여러 문제를 조회할 수 있도록 개선

### 서비스 계층
- `DailyProblemReader`의 메서드 반환 타입 변경:
  - `findDailyProblemByMember(Long memberId)` → `findDailyProblemsByMember(Long memberId)`: `DailyProblem`에서 `List<DailyProblem>`으로 변경
  - `findDailyProblem(LocalDate, Long memberId)` → `findDailyProblems(LocalDate, Long memberId)`: `Optional<DailyProblem>`에서 `List<DailyProblem>`으로 변경
- `DailyProblemService` 메서드 반환 타입 변경:
  - `getTodayProblem(Long memberId)`: `TodayProblemResponse`에서 `List<TodayProblemResponse>`로 변경, stream을 이용해 여러 문제를 DTO로 매핑
  - `findDailyProblem` 메서드 제거 및 `findDailyProblems(LocalDate, Long memberId)` 추가: `DailyProblemResponse`에서 `List<DailyProblemResponse>`로 변경, Optional 기반 공백 처리 제거

### 컨트롤러 계층
- `DailyProblemController`와 `DailyProblemDocsController`의 엔드포인트 변경:
  - `getTodayProblem` 엔드포인트: 응답 타입을 `ApiResponse<TodayProblemResponse>`에서 `ApiResponse<List<TodayProblemResponse>>`로 변경
  - `findDailyProblem` 엔드포인트 제거 및 `findDailyProblems` 엔드포인트 추가: 응답 타입을 `ApiResponse<DailyProblemResponse>`에서 `ApiResponse<List<DailyProblemResponse>>`로 변경

### 테스트 코드
- 모든 테스트에서 서비스 메서드 호출 스터빙과 어설션을 리스트 기반으로 업데이트
- `DailyProblemControllerTest`: JSON 응답 어설션을 `data.<field>`에서 `data[0].<field>` 형식으로 변경, 여러 카테고리의 문제를 날짜로 조회하는 새로운 테스트 케이스 추가
- `DailyProblemReaderIntegrationTest`: Optional 기반 어설션을 리스트 기반으로 변경, 동일 날짜에 서로 다른 카테고리의 여러 문제를 조회하는 테스트 케이스 추가
- `DailyProblemServiceUnitTest`: 단일 문제 조회에서 여러 문제 조회로 변경, 여러 카테고리 문제가 모두 반환되는지 검증하는 테스트 추가, 빈 리스트 반환 케이스 검증

## 영향 범위

### API 엔드포인트
- `GET /api/v1/daily-problems/today`: 응답 구조가 단일 객체에서 배열로 변경
- `GET /api/v1/daily-problems?date={date}`: 기존 엔드포인트명 변경 및 응답 구조가 단일 객체에서 배열로 변경

### 기능 영향
- 오늘의 문제 조회: 동일 날짜에 여러 문제가 있을 경우 모두 반환
- 날짜별 문제 조회: 특정 날짜의 모든 문제를 조회할 수 있음

### 통합 영향
- 해당 엔드포인트를 호출하는 모든 클라이언트 코드에서 응답 구조 변경에 대한 처리 필요

## 리뷰어 주목 포인트

1. **Optional 제거의 적절성**: `Optional<DailyProblem>`을 `List<DailyProblem>`으로 변경하면서 존재하지 않는 경우 빈 리스트를 반환하도록 변경. 이전에 예외 처리가 있었는지 확인하고, 빈 리스트 반환으로 인한 클라이언트 로직 변화가 적절한지 검토 필요

2. **N+1 쿼리 가능성**: `findAllByMemberIdAndAssignedAtAndStatus`에서 여러 `DailyProblem`을 반환할 때, JOIN FETCH를 사용한 쿼리가 제대로 최적화되어 있는지 확인 필요. 관련된 엔티티(예: 문제, 카테고리 등)의 지연 로딩으로 인한 추가 쿼리가 발생하지 않는지 검토

3. **API 응답 일관성**: 응답 구조가 배열로 변경되었을 때, 빈 배열 반환 시 클라이언트에서 적절하게 처리할 수 있는지, API 문서(Swagger/Docs)가 제대로 업데이트되었는지 확인

4. **트랜잭션 범위**: 서비스 계층에서 `List<DailyProblem>`을 반환받아 stream으로 DTO로 변환할 때, 지연 로딩 발생 시 트랜잭션이 닫혀있지 않은 상태에서 접근하는 문제 가능성 검토

5. **엔드포인트명 변경**: `findDailyProblem`에서 `findDailyProblems`로 변경되었는데, 관련된 모든 참조(클라이언트, 문서, 라우팅)가 일관되게 업데이트되었는지 확인

<!-- end of auto-generated comment: release notes by coderabbit.ai -->