### PR TITLE
Feat: 회원의 첫 문제 생성 시 캐시 무효화 기능 추가

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberService.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/member/service/MemberService.java
@@ -49,7 +49,7 @@ public class MemberService {
         Member member = memberManager.create(newProfile);
         MemberPreference memberPreference = memberManager.registerPreference(member, newPreference);
         streakManager.create(member);
-        // 회원가입 시에만 오늘의 문제 문제 직접 생성 - Async 처리
+        // 오늘의 문제 문제 직접 생성 - Async 처리
         problemGenerator.generateInitialProblem(member, memberPreference.getCategoryTopic(), memberPreference.getDifficulty());
 
         log.info("[MemberService] 회원 생성 및 학습 정보 등록 :{}, category: {}, difficulty: {}",

--- a/src/main/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGenerator.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGenerator.java
@@ -21,6 +21,7 @@ import org.kwakmunsu.haruhana.global.support.error.ErrorType;
 import org.kwakmunsu.haruhana.global.support.error.HaruHanaException;
 import org.kwakmunsu.haruhana.global.support.notification.ErrorNotificationSender;
 import org.kwakmunsu.haruhana.infrastructure.gemini.ChatService;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -88,12 +89,13 @@ public class ProblemGenerator {
     /**
      * 회원의 첫 문제를 생성하고 할당
      *
-     * @param member        회원가입 한 첫 회원
+     * @param member        회원
      * @param categoryTopic 카테고리 주제
      * @param difficulty    난이도
      */
     @Async
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @CacheEvict(cacheNames = "todayProblem", key = "#member.id + ':' + T(java.time.LocalDate).now()")
     public void generateInitialProblem(Member member, CategoryTopic categoryTopic, ProblemDifficulty difficulty) {
         LocalDate today = LocalDate.now();
         try {

--- a/src/main/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGenerator.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGenerator.java
@@ -95,7 +95,7 @@ public class ProblemGenerator {
      */
     @Async
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @CacheEvict(cacheNames = "todayProblem", key = "#member.id + ':' + T(java.time.LocalDate).now()")
+    @CacheEvict(cacheNames = "todayProblem", key = "#memberId + ':' + T(java.time.LocalDate).now()")
     public void generateInitialProblem(Member member, CategoryTopic categoryTopic, ProblemDifficulty difficulty) {
         LocalDate today = LocalDate.now();
         try {


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`: #214

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 한 줄 요약
회원이 첫 문제를 생성할 때 오늘의 문제 캐시를 무효화하도록 설정함

## 변경 내용
- ProblemGenerator.generateInitialProblem(...)에 캐시 무효화 추가
  - @CacheEvict(cacheNames = "todayProblem", key = "#memberId + ':' + T(java.time.LocalDate).now()") 어노테이션 추가로 해당 회원의 오늘의 문제 캐시를 무효화
  - 메서드는 비동기(@Async)·새 트랜잭션(@Transactional(propagation = Propagation.REQUIRES_NEW))으로 첫 문제를 생성하고 DailyProblemManager에 할당
- Javadoc 및 주석 정리
  - generateInitialProblem의 @param member 설명을 "회원"으로 일반화
  - MemberService의 회원 가입/선호도 추가 관련 주석에서 초기 문제 생성 설명 보완(동작은 변경 없음)
- MemberService에서 회원 생성(createMember) 및 선호도 추가(appendPreference) 시 problemGenerator.generateInitialProblem(...) 호출 유지
  - 초기 문제 생성은 기존과 같이 비동기 호출로 처리됨

## 영향 범위
- MemberService: 회원가입(createMember) 및 선호도 추가(appendPreference) 흐름에서 최초 문제 생성과 그에 따른 캐시 무효화에 영향
- DailyProblem 관련 캐시("todayProblem"): 특정 회원·당일에 대한 캐시 엔트리 무효화 로직 적용
- DailyProblemController 등 오늘의 문제 조회를 사용하는 API/로직: 무효화로 인한 캐시 일관성 변화

## 리뷰어 주목 포인트
- 비동기 메서드에서의 캐시 어노테이션 적용 여부: @Async로 실행되는 메서드에 대해 Spring 캐시가 예상대로 동작하는지 확인 필요
- 트랜잭션과 캐시 무효화 시점: generateInitialProblem은 REQUIRES_NEW 트랜잭션에서 실행되므로 캐시 무효화가 커밋 시점/커밋 이후 기대한 타이밍에 발생하는지 검토
- 캐시 키 표현식의 정확성: SpEL key로 "#memberId + ':' + T(java.time.LocalDate).now()"를 사용하고 있는데 메서드 파라미터는 Member member임. 실제로 올바른 멤버 식별자(예: member.id)를 참조하는지, 혹은 다른 변수명 불일치로 인해 캐시가 제대로 무효화되는지 확인 필요
- 날짜 경계 처리(자정 근처): T(java.time.LocalDate).now() 기반 키 생성은 자정 전후 실행 시 날짜 경계에 따른 무효화 누락 가능성 검토
<!-- end of auto-generated comment: release notes by coderabbit.ai -->