### PR TITLE
Fix: 오늘의 문제 결과 캐시 및 CacheEvict 키 오류 해결

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/domain/dailyproblem/service/DailyProblemService.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/dailyproblem/service/DailyProblemService.java
@@ -27,7 +27,11 @@ public class DailyProblemService {
      *
      * @param memberId 회원 ID
      */
-    @Cacheable(cacheNames = "todayProblem", key = "#memberId + ':' + T(java.time.LocalDate).now()")
+    @Cacheable(
+            cacheNames = "todayProblem",
+            key = "#memberId + ':' + T(java.time.LocalDate).now()",
+            unless = "#result == null || #result.isEmpty()"
+    )
     public List<TodayProblemResponse> getTodayProblem(Long memberId) {
         log.debug("[DailyProblemService] 오늘의 문제 캐시 미스 - 조회 시작");
         List<DailyProblem> dailyProblems = dailyProblemReader.findDailyProblemsByMember(memberId);

--- a/src/main/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGenerator.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGenerator.java
@@ -95,7 +95,7 @@ public class ProblemGenerator {
      */
     @Async
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @CacheEvict(cacheNames = "todayProblem", key = "#memberId + ':' + T(java.time.LocalDate).now()")
+    @CacheEvict(cacheNames = "todayProblem", key = "#member.id + ':' + T(java.time.LocalDate).now()")
     public void generateInitialProblem(Member member, CategoryTopic categoryTopic, ProblemDifficulty difficulty) {
         LocalDate today = LocalDate.now();
         try {


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`: #219 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 한 줄 요약
오늘의 문제 캐싱 전략을 개선하고 캐시 무효화 키 오류를 수정하여 캐시 동작을 정상화함

## 변경 내용

- **DailyProblemService.getTodayProblem()의 캐싱 조건 강화**: `@Cacheable` 어노테이션에 `unless = "#result == null || #result.isEmpty()"` 조건을 추가했습니다. 이제 조회 결과가 null이거나 빈 리스트인 경우 캐시에 저장되지 않으므로, 다음 조회 시 항상 데이터베이스에서 최신 데이터를 가져올 수 있습니다.

- **ProblemGenerator.generateInitialProblem()의 캐시 무효화 키 수정**: `@CacheEvict` 어노테이션의 key 표현식을 `#memberId + ':' + T(java.time.LocalDate).now()`에서 `#member.id + ':' + T(java.time.LocalDate).now()`로 변경했습니다. 이전 코드의 `#memberId`는 메서드의 매개변수에 존재하지 않는 변수 참조로, 캐시 무효화가 제대로 작동하지 않았습니다. 메서드 매개변수의 `Member member` 객체에서 `id` 프로퍼티를 올바르게 참조하도록 수정했습니다.

## 영향 범위

- **오늘의 문제 조회 API** (`GET /v1/daily-problem/today`): 빈 결과나 null 결과가 캐싱되지 않으므로 사용자가 항상 최신 데이터를 조회할 수 있습니다.

- **회원 가입 및 학습 선호도 추가 흐름**: `MemberService`에서 회원 생성 또는 학습 선호도를 추가할 때 `generateInitialProblem()` 메서드가 호출되며, 이제 해당 회원의 오늘 문제 캐시가 올바르게 무효화됩니다.

- **회원별 문제 생성 및 할당**: 첫 문제 생성 시 관련된 회원의 캐시가 정확히 초기화되어 새로 생성된 문제가 바로 조회될 수 있습니다.

## 리뷰어 주목 포인트

- **캐시 키 일관성**: `DailyProblemService.getTodayProblem()` 캐시 키(`#memberId + ':' + T(java.time.LocalDate).now()`)와 `ProblemGenerator.generateInitialProblem()` 무효화 키(`#member.id + ':' + T(java.time.LocalDate).now()`)가 동일한 형식으로 유지되는지 확인하세요. 둘 다 `memberId:LocalDate` 형식이므로 정상입니다.

- **Async 처리와 캐시 무효화의 타이밍**: `generateInitialProblem()` 메서드는 `@Async`로 비동기 처리되고 `@Transactional(propagation = Propagation.REQUIRES_NEW)`를 사용합니다. 캐시 무효화가 트랜잭션 커밋 후 발생하는지, 비동기 실행 중 경쟁 조건이 발생하지는 않는지 확인하세요.

- **null과 빈 리스트 처리**: `getTodayProblem()`의 `unless` 조건에서 `#result.isEmpty()`를 사용하기 전에 `#result == null`을 먼저 체크하고 있으므로 NPE 위험은 없습니다. 다만 빈 리스트를 반환하는 경우가 정상적인 비즈니스 케이스인지 확인하세요.

- **메서드 서명 변경 없음**: 공개 API 서명이 변경되지 않았으므로 하위 호환성이 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->