### PR TITLE
Fix: Fix: todayProblem stale(non-empty) 캐시 이슈 수정: generateInitialProblem after-commit 캐시 무효화 보장

### DIFF
--- a/src/main/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGenerator.java
+++ b/src/main/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGenerator.java
@@ -2,6 +2,7 @@ package org.kwakmunsu.haruhana.domain.problem.service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,11 +22,13 @@ import org.kwakmunsu.haruhana.global.support.error.ErrorType;
 import org.kwakmunsu.haruhana.global.support.error.HaruHanaException;
 import org.kwakmunsu.haruhana.global.support.notification.ErrorNotificationSender;
 import org.kwakmunsu.haruhana.infrastructure.gemini.ChatService;
-import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.CacheManager;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -41,6 +44,7 @@ public class ProblemGenerator {
     private final ProblemJpaRepository problemJpaRepository;
     private final DailyProblemManager dailyProblemManager;
     private final ErrorNotificationSender errorNotificationSender;
+    private final CacheManager cacheManager;
 
     @Transactional
     public void generateProblem(LocalDate targetDate) {
@@ -88,6 +92,7 @@ public class ProblemGenerator {
 
     /**
      * 회원의 첫 문제를 생성하고 할당
+     * 트랜잭션 커밋 이후에 todayProblem 캐시를 무효화하여 동시성 이슈를 방지합니다.
      *
      * @param member        회원
      * @param categoryTopic 카테고리 주제
@@ -95,7 +100,6 @@ public class ProblemGenerator {
      */
     @Async
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @CacheEvict(cacheNames = "todayProblem", key = "#member.id + ':' + T(java.time.LocalDate).now()")
     public void generateInitialProblem(Member member, CategoryTopic categoryTopic, ProblemDifficulty difficulty) {
         LocalDate today = LocalDate.now();
         try {
@@ -114,6 +118,9 @@ public class ProblemGenerator {
             // 기존 메서드 사용 할려고 그냥 List로 감싸서 보냄
             dailyProblemManager.assignDailyProblemToMembers(problem, List.of(member), today);
 
+            // 트랜잭션 커밋 이후에 캐시 무효화를 보장
+            registerCacheEvictionAfterCommit(member.getId(), today);
+
             log.info("[ProblemGenerator] 첫 문제 생성 완료 - 카테고리: {}, 난이도: {}, 대상 회원: {}",
                     categoryTopic.getName(),
                     difficulty,
@@ -124,6 +131,23 @@ public class ProblemGenerator {
 
             assignBackupProblem(categoryTopic.getId(), categoryTopic.getName(), difficulty, List.of(member), today);
         }
+    }
+
+    /**
+     * 트랜잭션 커밋 후 todayProblem 캐시 무효화
+     */
+    private void registerCacheEvictionAfterCommit(Long memberId, LocalDate date) {
+        TransactionSynchronizationManager.registerSynchronization(
+            new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    String cacheKey = memberId + ":" + date;
+                    Objects.requireNonNull(cacheManager.getCache("todayProblem")).evict(cacheKey);
+
+                    log.debug("[ProblemGenerator] todayProblem 캐시 무효화 - memberId: {}, date: {}", memberId, date);
+                }
+            }
+        );
     }
 
     /**

--- a/src/test/java/org/kwakmunsu/haruhana/domain/dailyproblem/service/DailyProblemCacheTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/dailyproblem/service/DailyProblemCacheTest.java
@@ -167,6 +167,86 @@ class DailyProblemCacheTest extends IntegrationTestSupport {
     }
 
     // ──────────────────────────────────────────────────────────────
+    // generateInitialProblem 캐시 무효화 회귀 테스트
+    // ──────────────────────────────────────────────────────────────
+
+    @Test
+    void 오늘의_문제가_없을_때_empty_결과는_캐시에_저장되지_않는다() {
+        // given: DB에 문제 없음 (신규 회원 - 아직 문제 미생성 상태)
+        var memberId = 1L;
+        given(dailyProblemReader.findDailyProblemsByMember(memberId)).willReturn(List.of());
+
+        // when: 2번 연속 조회
+        dailyProblemService.getTodayProblem(memberId);
+        dailyProblemService.getTodayProblem(memberId);
+
+        // then: unless 조건으로 empty 결과는 캐시되지 않음 → DB 2번 호출
+        verify(dailyProblemReader, times(2)).findDailyProblemsByMember(memberId);
+        assertThat(
+                Objects.requireNonNull(cacheManager.getCache("todayProblem"))
+                        .get(memberId + ":" + LocalDate.now())
+        ).isNull();
+    }
+
+    @Test
+    void empty_캐시_상태에서_generateInitialProblem_커밋_후_무효화_시_신규_데이터를_반환한다() {
+        // given: 첫 조회 - 문제 없음, empty 결과는 캐시 저장 안됨
+        var memberId = 1L;
+        var cacheKey = memberId + ":" + LocalDate.now();
+        given(dailyProblemReader.findDailyProblemsByMember(memberId)).willReturn(List.of());
+        dailyProblemService.getTodayProblem(memberId);
+        assertThat(Objects.requireNonNull(cacheManager.getCache("todayProblem")).get(cacheKey)).isNull();
+
+        // when: generateInitialProblem afterCommit 에서 캐시 무효화 (empty 상태에서 evict는 no-op, 안전해야 함)
+        cacheManager.getCache("todayProblem").evict(cacheKey);
+
+        // DB에 문제 생성됨 (비동기 트랜잭션 커밋 완료 이후 상태)
+        var member = MemberFixture.createMember(Role.ROLE_MEMBER);
+        var problem = ProblemFixture.createProblem(CategoryTopicFixture.createCategoryTopic());
+        var newDailyProblem = DailyProblemFixture.createUnsolvedDailyProblem(1L, member, problem);
+        given(dailyProblemReader.findDailyProblemsByMember(memberId)).willReturn(List.of(newDailyProblem));
+
+        // when: 재조회
+        var result = dailyProblemService.getTodayProblem(memberId);
+
+        // then: stale empty가 아닌 신규 데이터 반환
+        assertThat(result).hasSize(1);
+        // then: DB 재호출 (empty 조회 1번 + 무효화 후 재조회 1번)
+        verify(dailyProblemReader, times(2)).findDailyProblemsByMember(memberId);
+    }
+
+    @Test
+    void stale_non_empty_캐시_상태에서_generateInitialProblem_커밋_후_무효화_시_신규_데이터를_반환한다() {
+        // given: 기존 1개 문제로 캐시 채우기 (stale non-empty 상태 재현)
+        var memberId = 1L;
+        var cacheKey = memberId + ":" + LocalDate.now();
+        var member = MemberFixture.createMember(Role.ROLE_MEMBER);
+        var problem = ProblemFixture.createProblem(CategoryTopicFixture.createCategoryTopic());
+        var existingDailyProblem = DailyProblemFixture.createUnsolvedDailyProblem(1L, member, problem);
+
+        given(dailyProblemReader.findDailyProblemsByMember(memberId)).willReturn(List.of(existingDailyProblem));
+        dailyProblemService.getTodayProblem(memberId);
+        assertThat(Objects.requireNonNull(cacheManager.getCache("todayProblem")).get(cacheKey)).isNotNull();
+
+        // when: generateInitialProblem afterCommit 에서 stale 캐시 무효화
+        cacheManager.getCache("todayProblem").evict(cacheKey);
+        assertThat(cacheManager.getCache("todayProblem").get(cacheKey)).isNull();
+
+        // DB에 신규 문제 추가됨
+        var newDailyProblem = DailyProblemFixture.createUnsolvedDailyProblem(2L, member, problem);
+        given(dailyProblemReader.findDailyProblemsByMember(memberId))
+                .willReturn(List.of(existingDailyProblem, newDailyProblem));
+
+        // when: 재조회
+        var result = dailyProblemService.getTodayProblem(memberId);
+
+        // then: stale 캐시(1개)가 아닌 fresh 데이터(2개) 반환
+        assertThat(result).hasSize(2);
+        // then: DB 재호출 (캐시 채우기 1번 + 무효화 후 재조회 1번)
+        verify(dailyProblemReader, times(2)).findDailyProblemsByMember(memberId);
+    }
+
+    // ──────────────────────────────────────────────────────────────
     // dailyProblemDetail 캐시
     // ──────────────────────────────────────────────────────────────
 

--- a/src/test/java/org/kwakmunsu/haruhana/domain/dailyproblem/service/DailyProblemCacheTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/dailyproblem/service/DailyProblemCacheTest.java
@@ -21,11 +21,13 @@ import org.kwakmunsu.haruhana.domain.member.enums.Role;
 import org.kwakmunsu.haruhana.domain.problem.ProblemFixture;
 import org.kwakmunsu.haruhana.domain.streak.service.StreakManager;
 import org.kwakmunsu.haruhana.domain.submission.SubmissionFixture;
+import org.kwakmunsu.haruhana.domain.submission.service.FeedbackGradingService;
 import org.kwakmunsu.haruhana.domain.submission.service.SubmissionManager;
 import org.kwakmunsu.haruhana.domain.submission.service.SubmissionReader;
 import org.kwakmunsu.haruhana.domain.submission.service.SubmissionService;
 import org.kwakmunsu.haruhana.domain.submission.service.dto.response.SubmissionResult;
 import org.springframework.cache.CacheManager;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 /**
@@ -50,9 +52,18 @@ class DailyProblemCacheTest extends IntegrationTestSupport {
     @MockitoBean
     SubmissionManager submissionManager;
 
+    // 캐시 무효화 테스트 범위를 벗어나는 비동기 이벤트 체인을 차단
+    @MockitoBean
+    ApplicationEventPublisher eventPublisher;
+
     // 비동기 이벤트 핸들러(SubmissionEventHandler)가 DB에 접근하지 않도록 차단
     @MockitoBean
     StreakManager streakManager;
+
+    // @MockitoBean ApplicationEventPublisher는 ApplicationContext 자체가 주입될 수 있어
+    // 실제 이벤트가 발행될 수 있음 → FeedbackGradingService를 직접 차단
+    @MockitoBean
+    FeedbackGradingService feedbackGradingService;
 
     @AfterEach
     void clearCache() {

--- a/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberServiceIntegrationTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/member/service/MemberServiceIntegrationTest.java
@@ -245,6 +245,8 @@ class MemberServiceIntegrationTest extends IntegrationTestSupport {
         // then
         var count = memberPreferenceJpaRepository.countByMemberIdAndStatus(memberId, org.kwakmunsu.haruhana.global.entity.EntityStatus.ACTIVE);
         assertThat(count).isEqualTo(2);
+        // 선호 정보 추가 시 비동기로 초기 문제 생성
+        verify(problemGenerator, times(2)).generateInitialProblem(any(), any(), any());
     }
 
     @Test

--- a/src/test/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGeneratorIntegrationTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGeneratorIntegrationTest.java
@@ -229,4 +229,5 @@ class ProblemGeneratorIntegrationTest extends IntegrationTestSupport {
         assertThat(dailyProblems).hasSize(2);
     }
 
+
 }

--- a/src/test/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGeneratorUnitTest.java
+++ b/src/test/java/org/kwakmunsu/haruhana/domain/problem/service/ProblemGeneratorUnitTest.java
@@ -28,6 +28,7 @@ import org.kwakmunsu.haruhana.global.support.notification.ErrorNotificationSende
 import org.kwakmunsu.haruhana.infrastructure.gemini.ChatService;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.cache.CacheManager;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class ProblemGeneratorUnitTest extends UnitTestSupport {
@@ -46,6 +47,9 @@ class ProblemGeneratorUnitTest extends UnitTestSupport {
 
     @Mock
     ErrorNotificationSender errorNotificationSender;
+
+    @Mock
+    CacheManager cacheManager;
 
     @InjectMocks
     ProblemGenerator problemGenerator;


### PR DESCRIPTION
## 📌 관련 이슈
✅ `Issue`:  #221 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 한 줄 요약
`generateInitialProblem` 메서드의 캐시 무효화를 트랜잭션 커밋 후에 실행하도록 변경하여 todayProblem 캐시의 stale 이슈를 해결함.

## 변경 내용

### ProblemGenerator.java - 캐시 무효화 로직 개선
- **CacheManager 의존성 추가**: Spring의 CacheManager를 주입받아 프로그래매틱 캐시 제어 가능
- **TransactionSynchronization 활용**: `registerCacheEvictionAfterCommit` 메서드를 추가하여 `TransactionSynchronizationManager`에 콜백을 등록. 트랜잭션이 성공적으로 커밋된 후에만 `afterCommit()` 메서드에서 캐시를 무효화함으로써 동시성 이슈 방지
- **캐시 키 생성**: `memberId + ":" + date` 형식의 동적 키로 특정 회원의 특정 날짜 캐시만 정확히 무효화
- **이전 방식 제거**: 스프링 `@CacheEvict` 데코레이터를 프로그래매틱 방식으로 대체하여 타이밍 제어 강화

### DailyProblemCacheTest - 캐시 무효화 회귀 테스트 추가
- **비동기 이벤트 체인 차단**: `ApplicationEventPublisher`와 `FeedbackGradingService`를 MockitoBean으로 추가하여 테스트 중 외부 비동기 이벤트 간섭 제거
- **3가지 캐시 시나리오 테스트**:
  1. 빈 결과 캐싱 불가 검증: 문제가 없을 때 빈 결과가 캐시되지 않고 반복 조회 시 DB 호출 확인
  2. 초기 빈 캐시 무효화: 캐시가 비어있는 상태에서 무효화 후 신규 데이터 반환 및 DB 재호출 확인
  3. Stale 비어있지 않은 캐시 무효화: 기존 데이터로 채워진 캐시를 무효화한 후 더 많은 신규 데이터 반환 확인 (이슈 #221의 핵심 시나리오)

### MemberServiceIntegrationTest - 초기 문제 생성 호출 검증
- 회원의 학습 선호 정보 추가 후 `problemGenerator.generateInitialProblem` 호출 횟수를 검증하는 assertion 추가

### ProblemGeneratorUnitTest - 테스트 모킹 강화
- `CacheManager` mock 필드 추가로 단위 테스트 시 `ProblemGenerator`에 주입되는 캐시 관리 기능 모킹

## 영향 범위
- **`generateInitialProblem` 메서드**: 회원 최초 문제 생성 시 캐시 무효화 타이밍 변경
- **todayProblem 캐시**: 회원별 오늘 날짜의 문제 목록 캐시의 일관성 보장
- **DailyProblemService**: 캐시된 오늘의 문제 조회 시 stale 데이터 반환 가능성 제거
- **회원 선호도 추가 플로우**: 새로운 카테고리 선호도 추가 시 초기 문제 비동기 생성 흐름

## 리뷰어 주목 포인트

1. **트랜잭션 경계 확인**: `generateInitialProblem` 메서드가 `@Transactional(propagation = Propagation.REQUIRES_NEW)`로 설정되어 새 트랜잭션을 생성하고, 커밋 후 캐시 무효화가 실행되도록 보장하는지 검증

2. **캐시 키 일치성**: 캐시 저장 시 사용되는 키(`memberId + ":" + date`)와 무효화 시 사용되는 키가 정확히 일치하는지 확인. 특히 `LocalDate.now()`의 일관성 여부 점검

3. **NullPointerException 방어**: `Objects.requireNonNull(cacheManager.getCache("todayProblem"))`에서 캐시가 존재하지 않을 경우 예외 발생 가능성. 프로덕션 환경에서 `todayProblem` 캐시가 정확히 설정되어 있는지 확인 필요

4. **비동기 메서드의 트랜잭션 처리**: `@Async` + `@Transactional(REQUIRES_NEW)` 조합에서 비동기 스레드의 트랜잭션이 올바르게 커밋되고 동기화되는지 검증

5. **캐시 무효화 순서**: 문제 저장 → 일일 문제 할당 → 캐시 무효화 등록 순서가 논리적으로 타당한지 확인. 만약 할당 과정에서 예외 발생 시 캐시 무효화 콜백의 등록 여부

6. **테스트 격리성**: MockitoBean으로 추가된 이벤트 퍼블리셔 모킹이 다른 테스트에 영향을 주지 않는지, 그리고 실제 비동기 이벤트 처리가 제대로 작동하는지 통합 테스트로 별도 검증 필요

<!-- end of auto-generated comment: release notes by coderabbit.ai -->